### PR TITLE
frame: added pointers to both request and response

### DIFF
--- a/frame/request/authresponse.go
+++ b/frame/request/authresponse.go
@@ -9,10 +9,10 @@ type AuthResponse struct {
 	Token frame.Bytes
 }
 
-func (a AuthResponse) WriteTo(b *frame.Buffer) {
+func (a *AuthResponse) WriteTo(b *frame.Buffer) {
 	b.WriteBytes(a.Token)
 }
 
-func (AuthResponse) OpCode() frame.OpCode {
+func (*AuthResponse) OpCode() frame.OpCode {
 	return frame.OpAuthResponse
 }

--- a/frame/request/batch.go
+++ b/frame/request/batch.go
@@ -20,7 +20,7 @@ type Batch struct {
 }
 
 // WriteTo writes Batch body into bytes.Buffer.
-func (q Batch) WriteTo(b *frame.Buffer) { // nolint:gocritic
+func (q *Batch) WriteTo(b *frame.Buffer) {
 	b.WriteBatchTypeFlag(q.Type)
 
 	// WriteTo number of queries.
@@ -38,7 +38,7 @@ func (q Batch) WriteTo(b *frame.Buffer) { // nolint:gocritic
 	}
 }
 
-func (Batch) OpCode() frame.OpCode {
+func (*Batch) OpCode() frame.OpCode {
 	return frame.OpBatch
 }
 
@@ -51,7 +51,7 @@ type BatchQuery struct {
 	Values   []frame.Value
 }
 
-func (q BatchQuery) WriteTo(b *frame.Buffer, name bool) { // nolint:gocritic
+func (q *BatchQuery) WriteTo(b *frame.Buffer, name bool) {
 	b.WriteByte(q.Kind)
 	if q.Kind == 0 {
 		b.WriteLongString(q.Query)

--- a/frame/request/execute.go
+++ b/frame/request/execute.go
@@ -10,11 +10,11 @@ type Execute struct {
 	Options frame.QueryOptions
 }
 
-func (e Execute) WriteTo(b *frame.Buffer) { // nolint:gocritic
+func (e *Execute) WriteTo(b *frame.Buffer) {
 	b.WriteShortBytes(e.ID)
 	b.WriteQueryOptions(e.Options)
 }
 
-func (Execute) OpCode() frame.OpCode {
+func (*Execute) OpCode() frame.OpCode {
 	return frame.OpExecute
 }

--- a/frame/request/options.go
+++ b/frame/request/options.go
@@ -7,8 +7,8 @@ import (
 // Options spec https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L330.
 type Options struct{}
 
-func (Options) WriteTo(_ *frame.Buffer) {}
+func (*Options) WriteTo(_ *frame.Buffer) {}
 
-func (Options) OpCode() frame.OpCode {
+func (*Options) OpCode() frame.OpCode {
 	return frame.OpOptions
 }

--- a/frame/request/prepare.go
+++ b/frame/request/prepare.go
@@ -9,10 +9,10 @@ type Prepare struct {
 	Query string
 }
 
-func (p Prepare) WriteTo(b *frame.Buffer) {
+func (p *Prepare) WriteTo(b *frame.Buffer) {
 	b.WriteLongString(p.Query)
 }
 
-func (Prepare) OpCode() frame.OpCode {
+func (*Prepare) OpCode() frame.OpCode {
 	return frame.OpPrepare
 }

--- a/frame/request/query.go
+++ b/frame/request/query.go
@@ -11,12 +11,12 @@ type Query struct {
 	Options     frame.QueryOptions
 }
 
-func (q Query) WriteTo(b *frame.Buffer) { // nolint:gocritic
+func (q *Query) WriteTo(b *frame.Buffer) {
 	b.WriteLongString(q.Query)
 	b.WriteConsistency(q.Consistency)
 	b.WriteQueryOptions(q.Options)
 }
 
-func (Query) OpCode() frame.OpCode {
+func (*Query) OpCode() frame.OpCode {
 	return frame.OpQuery
 }

--- a/frame/request/register.go
+++ b/frame/request/register.go
@@ -9,10 +9,10 @@ type Register struct {
 	EventTypes []frame.EventType
 }
 
-func (r Register) WriteTo(b *frame.Buffer) {
+func (r *Register) WriteTo(b *frame.Buffer) {
 	b.WriteEventTypes(r.EventTypes)
 }
 
-func (Register) OpCode() frame.OpCode {
+func (*Register) OpCode() frame.OpCode {
 	return frame.OpRegister
 }

--- a/frame/request/startup.go
+++ b/frame/request/startup.go
@@ -9,10 +9,10 @@ type Startup struct {
 	Options frame.StartupOptions
 }
 
-func (s Startup) WriteTo(b *frame.Buffer) {
+func (s *Startup) WriteTo(b *frame.Buffer) {
 	b.WriteStartupOptions(s.Options)
 }
 
-func (Startup) OpCode() frame.OpCode {
+func (*Startup) OpCode() frame.OpCode {
 	return frame.OpStartup
 }

--- a/frame/response/authchallenge.go
+++ b/frame/response/authchallenge.go
@@ -9,8 +9,8 @@ type AuthChallenge struct {
 	Token frame.Bytes
 }
 
-func ParseAuthChallenge(b *frame.Buffer) AuthChallenge {
-	return AuthChallenge{
+func ParseAuthChallenge(b *frame.Buffer) *AuthChallenge {
+	return &AuthChallenge{
 		Token: b.ReadBytes(),
 	}
 }

--- a/frame/response/authchallenge_test.go
+++ b/frame/response/authchallenge_test.go
@@ -47,7 +47,7 @@ func TestAuthChallenge(t *testing.T) {
 			var buf frame.Buffer
 			buf.Write(tc.content)
 			a := ParseAuthChallenge(&buf)
-			if diff := cmp.Diff(a, tc.expected); diff != "" {
+			if diff := cmp.Diff(*a, tc.expected); diff != "" {
 				t.Fatal(diff)
 			}
 		})

--- a/frame/response/authenticate.go
+++ b/frame/response/authenticate.go
@@ -9,8 +9,8 @@ type Authenticate struct {
 	Name string
 }
 
-func ParseAuthenticate(b *frame.Buffer) Authenticate {
-	return Authenticate{
+func ParseAuthenticate(b *frame.Buffer) *Authenticate {
+	return &Authenticate{
 		Name: b.ReadString(),
 	}
 }

--- a/frame/response/authsuccess.go
+++ b/frame/response/authsuccess.go
@@ -9,8 +9,8 @@ type AuthSuccess struct {
 	Token frame.Bytes
 }
 
-func ParseAuthSuccess(b *frame.Buffer) AuthSuccess {
-	return AuthSuccess{
+func ParseAuthSuccess(b *frame.Buffer) *AuthSuccess {
+	return &AuthSuccess{
 		Token: b.ReadBytes(),
 	}
 }

--- a/frame/response/error.go
+++ b/frame/response/error.go
@@ -11,8 +11,8 @@ type Error struct {
 	Message string
 }
 
-func ParseError(b *frame.Buffer) Error {
-	return Error{
+func ParseError(b *frame.Buffer) *Error {
+	return &Error{
 		Code:    b.ReadErrorCode(),
 		Message: b.ReadString(),
 	}
@@ -26,8 +26,8 @@ type UnavailableError struct {
 	Alive       frame.Int
 }
 
-func ParseUnavailableError(b *frame.Buffer) UnavailableError {
-	return UnavailableError{
+func ParseUnavailableError(b *frame.Buffer) *UnavailableError {
+	return &UnavailableError{
 		Error: Error{
 			Code:    b.ReadErrorCode(),
 			Message: b.ReadString(),
@@ -47,8 +47,8 @@ type WriteTimeoutError struct {
 	WriteType   frame.WriteType
 }
 
-func ParseWriteTimeoutError(b *frame.Buffer) WriteTimeoutError {
-	return WriteTimeoutError{
+func ParseWriteTimeoutError(b *frame.Buffer) *WriteTimeoutError {
+	return &WriteTimeoutError{
 		Error: Error{
 			Code:    b.ReadErrorCode(),
 			Message: b.ReadString(),
@@ -69,8 +69,8 @@ type ReadTimeoutError struct {
 	DataPresent frame.Byte
 }
 
-func ParseReadTimeoutError(b *frame.Buffer) ReadTimeoutError {
-	return ReadTimeoutError{
+func ParseReadTimeoutError(b *frame.Buffer) *ReadTimeoutError {
+	return &ReadTimeoutError{
 		Error: Error{
 			Code:    b.ReadErrorCode(),
 			Message: b.ReadString(),
@@ -92,8 +92,8 @@ type ReadFailureError struct {
 	DataPresent frame.Byte
 }
 
-func ParseReadFailureError(b *frame.Buffer) ReadFailureError {
-	return ReadFailureError{
+func ParseReadFailureError(b *frame.Buffer) *ReadFailureError {
+	return &ReadFailureError{
 		Error: Error{
 			Code:    b.ReadErrorCode(),
 			Message: b.ReadString(),
@@ -114,8 +114,8 @@ type FuncFailureError struct {
 	ArgTypes frame.StringList
 }
 
-func ParseFuncFailureError(b *frame.Buffer) FuncFailureError {
-	return FuncFailureError{
+func ParseFuncFailureError(b *frame.Buffer) *FuncFailureError {
+	return &FuncFailureError{
 		Error: Error{
 			Code:    b.ReadErrorCode(),
 			Message: b.ReadString(),
@@ -136,8 +136,8 @@ type WriteFailureError struct {
 	WriteType   frame.WriteType
 }
 
-func ParseWriteFailureError(b *frame.Buffer) WriteFailureError {
-	return WriteFailureError{
+func ParseWriteFailureError(b *frame.Buffer) *WriteFailureError {
+	return &WriteFailureError{
 		Error: Error{
 			Code:    b.ReadErrorCode(),
 			Message: b.ReadString(),
@@ -157,8 +157,8 @@ type AlreadyExistsError struct {
 	Table    string
 }
 
-func ParseAlreadyExistsError(b *frame.Buffer) AlreadyExistsError {
-	return AlreadyExistsError{
+func ParseAlreadyExistsError(b *frame.Buffer) *AlreadyExistsError {
+	return &AlreadyExistsError{
 		Error: Error{
 			Code:    b.ReadErrorCode(),
 			Message: b.ReadString(),
@@ -174,8 +174,8 @@ type UnpreparedError struct {
 	UnknownID frame.ShortBytes
 }
 
-func ParseUnpreparedError(b *frame.Buffer) UnpreparedError {
-	return UnpreparedError{
+func ParseUnpreparedError(b *frame.Buffer) *UnpreparedError {
+	return &UnpreparedError{
 		Error: Error{
 			Code:    b.ReadErrorCode(),
 			Message: b.ReadString(),

--- a/frame/response/error_test.go
+++ b/frame/response/error_test.go
@@ -87,7 +87,7 @@ func TestValidErrorCodes(t *testing.T) {
 			var buf frame.Buffer
 			buf.Write(tc.content)
 			out := ParseError(&buf)
-			if diff := cmp.Diff(out, tc.expected); diff != "" {
+			if diff := cmp.Diff(*out, tc.expected); diff != "" {
 				t.Fatal("Failure while constructing base error type.")
 			}
 		})
@@ -124,7 +124,7 @@ func TestUnavailableError(t *testing.T) {
 			var buf frame.Buffer
 			buf.Write(tc.content)
 			out := ParseUnavailableError(&buf)
-			if diff := cmp.Diff(out, tc.expected); diff != "" {
+			if diff := cmp.Diff(*out, tc.expected); diff != "" {
 				t.Fatal("Failure while constructing 'Unavailable' error.")
 			}
 		})
@@ -162,7 +162,7 @@ func TestWriteTimeoutError(t *testing.T) {
 			t.Parallel()
 			buf.Write(tc.content)
 			out := ParseWriteTimeoutError(&buf)
-			if out != tc.expected {
+			if diff := cmp.Diff(*out, tc.expected); diff != "" {
 				t.Fatal("Failure while constructing 'WriteTo Timeout' error.")
 			}
 		})
@@ -200,7 +200,7 @@ func TestReadTimeoutError(t *testing.T) {
 			var buf frame.Buffer
 			buf.Write(tc.content)
 			out := ParseReadTimeoutError(&buf)
-			if diff := cmp.Diff(out, tc.expected); diff != "" {
+			if diff := cmp.Diff(*out, tc.expected); diff != "" {
 				t.Fatal("Failure while constructing 'WriteTo Timeout' error.")
 			}
 		})
@@ -238,7 +238,7 @@ func TestReadFailureError(t *testing.T) { // nolint:dupl // Tests are different.
 			var buf frame.Buffer
 			buf.Write(tc.content)
 			out := ParseReadFailureError(&buf)
-			if diff := cmp.Diff(out, tc.expected); diff != "" {
+			if diff := cmp.Diff(*out, tc.expected); diff != "" {
 				t.Fatal("Failure while constructing 'WriteTo Timeout' error.")
 			}
 		})
@@ -275,7 +275,7 @@ func TestFuncFailureError(t *testing.T) {
 			var buf frame.Buffer
 			buf.Write(tc.content)
 			out := ParseFuncFailureError(&buf)
-			if diff := cmp.Diff(out, tc.expected); diff != "" {
+			if diff := cmp.Diff(*out, tc.expected); diff != "" {
 				t.Fatal("Failure while constructing 'Function Failure' error.")
 			}
 		})
@@ -314,7 +314,7 @@ func TestWriteFailureError(t *testing.T) { // nolint:dupl // Tests are different
 			var buf frame.Buffer
 			buf.Write(tc.content)
 			out := ParseWriteFailureError(&buf)
-			if diff := cmp.Diff(out, tc.expected); diff != "" {
+			if diff := cmp.Diff(*out, tc.expected); diff != "" {
 				t.Fatal("Failure while constructing 'Function Failure' error.")
 			}
 		})
@@ -349,7 +349,7 @@ func TestAlreadyExistsError(t *testing.T) {
 			var buf frame.Buffer
 			buf.Write(tc.content)
 			out := ParseAlreadyExistsError(&buf)
-			if diff := cmp.Diff(out, tc.expected); diff != "" {
+			if diff := cmp.Diff(*out, tc.expected); diff != "" {
 				t.Fatal(diff)
 			}
 		})
@@ -383,7 +383,7 @@ func TestUnpreparedError(t *testing.T) {
 			var buf frame.Buffer
 			buf.Write(tc.content)
 			out := ParseUnpreparedError(&buf)
-			if diff := cmp.Diff(out, tc.expected); diff != "" {
+			if diff := cmp.Diff(*out, tc.expected); diff != "" {
 				t.Fatal(diff)
 			}
 		})

--- a/frame/response/event.go
+++ b/frame/response/event.go
@@ -13,8 +13,8 @@ type TopologyChange struct {
 	Address frame.Inet
 }
 
-func ParseTopologyChange(b *frame.Buffer) TopologyChange {
-	return TopologyChange{
+func ParseTopologyChange(b *frame.Buffer) *TopologyChange {
+	return &TopologyChange{
 		Change:  b.ReadTopologyChangeType(),
 		Address: b.ReadInet(),
 	}
@@ -26,8 +26,8 @@ type StatusChange struct {
 	Address frame.Inet
 }
 
-func ParseStatusChange(b *frame.Buffer) StatusChange {
-	return StatusChange{
+func ParseStatusChange(b *frame.Buffer) *StatusChange {
+	return &StatusChange{
 		Status:  b.ReadStatusChangeType(),
 		Address: b.ReadInet(),
 	}
@@ -42,25 +42,25 @@ type SchemaChange struct {
 	Arguments frame.StringList
 }
 
-func ParseSchemaChange(b *frame.Buffer) SchemaChange {
+func ParseSchemaChange(b *frame.Buffer) *SchemaChange {
 	c := b.ReadSchemaChangeType()
 	t := b.ReadSchemaChangeTarget()
 	switch t {
 	case frame.Keyspace:
-		return SchemaChange{
+		return &SchemaChange{
 			Change:   c,
 			Target:   t,
 			Keyspace: b.ReadString(),
 		}
 	case frame.Table, frame.UserType:
-		return SchemaChange{
+		return &SchemaChange{
 			Change:   c,
 			Target:   t,
 			Keyspace: b.ReadString(),
 			Object:   b.ReadString(),
 		}
 	case frame.Function, frame.Aggregate:
-		return SchemaChange{
+		return &SchemaChange{
 			Change:    c,
 			Target:    t,
 			Keyspace:  b.ReadString(),
@@ -68,6 +68,6 @@ func ParseSchemaChange(b *frame.Buffer) SchemaChange {
 			Arguments: b.ReadStringList(),
 		}
 	default:
-		return SchemaChange{}
+		return &SchemaChange{}
 	}
 }

--- a/frame/response/event_test.go
+++ b/frame/response/event_test.go
@@ -42,7 +42,7 @@ func TestStatusChangeEvent(t *testing.T) { // nolint:dupl // Tests are different
 			var buf frame.Buffer
 			buf.Write(tc.content)
 			a := ParseStatusChange(&buf)
-			if diff := cmp.Diff(a, tc.expected); diff != "" {
+			if diff := cmp.Diff(*a, tc.expected); diff != "" {
 				t.Fatal(diff)
 			}
 		})
@@ -83,7 +83,7 @@ func TestTopologyChangeEvent(t *testing.T) { //nolint:dupl // Tests are differen
 			var buf frame.Buffer
 			buf.Write(tc.content)
 			a := ParseTopologyChange(&buf)
-			if diff := cmp.Diff(a, tc.expected); diff != "" {
+			if diff := cmp.Diff(*a, tc.expected); diff != "" {
 				t.Fatal(diff)
 			}
 		})
@@ -188,7 +188,7 @@ func TestSchemaChangeEvent(t *testing.T) {
 			var buf frame.Buffer
 			buf.Write(tc.content)
 			s := ParseSchemaChange(&buf)
-			if diff := cmp.Diff(s, tc.expected); diff != "" {
+			if diff := cmp.Diff(*s, tc.expected); diff != "" {
 				t.Fatal(diff)
 			}
 		})

--- a/frame/response/ready.go
+++ b/frame/response/ready.go
@@ -7,6 +7,6 @@ import (
 // Ready spec: https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L507
 type Ready struct{}
 
-func ParseReady(_ *frame.Buffer) Ready {
-	return Ready{}
+func ParseReady(_ *frame.Buffer) *Ready {
+	return &Ready{}
 }

--- a/frame/response/result.go
+++ b/frame/response/result.go
@@ -19,7 +19,7 @@ type RowsResult struct {
 	RowsContent []frame.Row
 }
 
-func ParseRowsResult(b *frame.Buffer) RowsResult {
+func ParseRowsResult(b *frame.Buffer) *RowsResult {
 	r := RowsResult{
 		Metadata: b.ReadResultMetadata(),
 		RowsCnt:  b.ReadInt(),
@@ -30,7 +30,7 @@ func ParseRowsResult(b *frame.Buffer) RowsResult {
 		r.RowsContent[i] = b.ReadRow(r.Metadata.ColumnsCnt)
 	}
 
-	return r
+	return &r
 }
 
 // SetKeyspaceResult spec: https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L669
@@ -38,8 +38,8 @@ type SetKeyspaceResult struct {
 	Name string
 }
 
-func ParseSetKeyspaceResult(b *frame.Buffer) SetKeyspaceResult {
-	return SetKeyspaceResult{
+func ParseSetKeyspaceResult(b *frame.Buffer) *SetKeyspaceResult {
+	return &SetKeyspaceResult{
 		Name: b.ReadString(),
 	}
 }
@@ -51,8 +51,8 @@ type PreparedResult struct {
 	ResultMetadata frame.ResultMetadata
 }
 
-func ParsePreparedResult(b *frame.Buffer) PreparedResult {
-	return PreparedResult{
+func ParsePreparedResult(b *frame.Buffer) *PreparedResult {
+	return &PreparedResult{
 		ID:             b.ReadShortBytes(),
 		Metadata:       b.ReadPreparedMetadata(),
 		ResultMetadata: b.ReadResultMetadata(),
@@ -64,8 +64,8 @@ type SchemaChangeResult struct {
 	SchemaChange SchemaChange
 }
 
-func ParseSchemaChangeResult(b *frame.Buffer) SchemaChangeResult {
-	return SchemaChangeResult{
-		SchemaChange: ParseSchemaChange(b),
+func ParseSchemaChangeResult(b *frame.Buffer) *SchemaChangeResult {
+	return &SchemaChangeResult{
+		SchemaChange: *ParseSchemaChange(b),
 	}
 }

--- a/frame/response/result_test.go
+++ b/frame/response/result_test.go
@@ -129,7 +129,7 @@ func TestRowsResult(t *testing.T) {
 			var buf frame.Buffer
 			buf.Write(tc.content)
 			a := ParseRowsResult(&buf)
-			if diff := cmp.Diff(a, tc.expected); diff != "" {
+			if diff := cmp.Diff(*a, tc.expected); diff != "" {
 				t.Fatal(diff)
 			}
 		})
@@ -161,7 +161,7 @@ func TestSetKeyspaceResult(t *testing.T) {
 			var buf frame.Buffer
 			buf.Write(tc.content)
 			a := ParseSetKeyspaceResult(&buf)
-			if diff := cmp.Diff(a, tc.expected); diff != "" {
+			if diff := cmp.Diff(*a, tc.expected); diff != "" {
 				t.Fatal(diff)
 			}
 		})
@@ -357,7 +357,7 @@ func TestPreparedResult(t *testing.T) {
 			var buf frame.Buffer
 			buf.Write(tc.content)
 			a := ParsePreparedResult(&buf)
-			if diff := cmp.Diff(a, tc.expected); diff != "" {
+			if diff := cmp.Diff(*a, tc.expected); diff != "" {
 				t.Fatal(diff)
 			}
 		})
@@ -472,7 +472,7 @@ func TestSchemaChangeResult(t *testing.T) {
 			var buf frame.Buffer
 			buf.Write(tc.content)
 			a := ParseSchemaChangeResult(&buf)
-			if diff := cmp.Diff(a, tc.expected); diff != "" {
+			if diff := cmp.Diff(*a, tc.expected); diff != "" {
 				t.Fatal(diff)
 			}
 		})

--- a/frame/response/supported.go
+++ b/frame/response/supported.go
@@ -9,8 +9,8 @@ type Supported struct {
 	Options frame.StringMultiMap
 }
 
-func ParseSupported(b *frame.Buffer) Supported {
-	return Supported{
+func ParseSupported(b *frame.Buffer) *Supported {
+	return &Supported{
 		Options: b.ReadStringMultiMap(),
 	}
 }

--- a/frame/response/supported_test.go
+++ b/frame/response/supported_test.go
@@ -30,7 +30,7 @@ func TestSupportedEncodeDecode(t *testing.T) {
 			var out frame.Buffer
 			out.Write(tc.content)
 			a := ParseSupported(&out)
-			if diff := cmp.Diff(a, tc.expected); diff != "" {
+			if diff := cmp.Diff(*a, tc.expected); diff != "" {
 				t.Fatal(diff)
 			}
 			if len(out.Bytes()) != 0 {


### PR DESCRIPTION
All response parse functions are now returning pointer to the structs (#87)
WriteTo and OpCode functions are now called by structure pointers rather than their copies,
removed nolint:gocritic from some WriteTo functions, those were used to silence linter, but
there is no need to use them after most recent fixes (#86)