### PR TITLE
transport: add StreamIDAllocator

### DIFF
--- a/transport/conn.go
+++ b/transport/conn.go
@@ -194,7 +194,6 @@ func WrapConn(conn net.Conn) *Conn {
 		r: connReader{
 			conn: bufio.NewReaderSize(conn, ioBufferSize),
 			h:    make(map[frame.StreamID]responseHandler),
-			s:    streamIDAllocator{},
 		},
 	}
 	go c.w.loop()
@@ -214,7 +213,7 @@ func (c *Conn) sendRequest(req frame.Request, compress, tracing bool) (frame.Res
 
 	streamID, err := c.r.setHandler(h)
 	if err != nil {
-		return nil, fmt.Errorf("setHandler: %w", err)
+		return nil, fmt.Errorf("set handler: %w", err)
 	}
 
 	r := request{

--- a/transport/conn_integration_test.go
+++ b/transport/conn_integration_test.go
@@ -14,7 +14,7 @@ func TestConnStartup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	conn := WrapConn(nc, &DefaultStreamIDAllocator{})
+	conn := WrapConn(nc)
 
 	opts := frame.StartupOptions{
 		"CQL_VERSION": "3.0.0",

--- a/transport/conn_integration_test.go
+++ b/transport/conn_integration_test.go
@@ -14,7 +14,7 @@ func TestConnStartup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	conn := WrapConn(nc, TestStreamIDAllocator{})
+	conn := WrapConn(nc, &DefaultStreamIDAllocator{})
 
 	opts := frame.StartupOptions{
 		"CQL_VERSION": "3.0.0",

--- a/transport/stream.go
+++ b/transport/stream.go
@@ -27,7 +27,7 @@ func (s *streamIDAllocator) Alloc() (frame.StreamID, error) {
 			return frame.StreamID(offset + blockID*bucketSize), nil
 		}
 	}
-	return 0, fmt.Errorf("all stream ID's are busy")
+	return 0, fmt.Errorf("all stream IDs are busy")
 }
 
 func (s *streamIDAllocator) Free(id frame.StreamID) {

--- a/transport/stream.go
+++ b/transport/stream.go
@@ -1,10 +1,40 @@
 package transport
 
 import (
+	"fmt"
+	"math"
+	"math/bits"
 	"scylla-go-driver/frame"
 )
 
 type StreamIDAllocator interface {
 	Alloc() (frame.StreamID, error)
 	Free(id frame.StreamID)
+}
+
+const maxStreamID = math.MaxInt16
+
+const bucketSize = 64
+const buckets = (maxStreamID + 1) / bucketSize
+
+// DefaultStreamIDAllocator is a StreamIDAllocator that always allocates the smallest possible stream on Alloc().
+type DefaultStreamIDAllocator struct {
+	usedBitmap [buckets]uint64
+}
+
+func (s *DefaultStreamIDAllocator) Alloc() (frame.StreamID, error) {
+	for blockID, block := range &s.usedBitmap {
+		if block < math.MaxUint64 {
+			offset := bits.TrailingZeros64(^block)
+			s.usedBitmap[blockID] |= 1 << offset
+			return frame.StreamID(offset + blockID*bucketSize), nil
+		}
+	}
+	return 0, fmt.Errorf("stream ID alloc: all stream ID's are busy")
+}
+
+func (s *DefaultStreamIDAllocator) Free(id frame.StreamID) {
+	blockID := id / bucketSize
+	offset := id % bucketSize
+	s.usedBitmap[blockID] ^= 1 << offset
 }

--- a/transport/stream_test.go
+++ b/transport/stream_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 )
 
-func TestDefaultStreamAllocatorAlloc(t *testing.T) {
+func TestStreamIDAllocator(t *testing.T) {
 	t.Parallel()
 	s := streamIDAllocator{}
 
 	allocated := make(map[frame.StreamID]struct{})
 
-	// Check if allocating all possible non-negative streams is possible.
+	// Allocate all possible non-negative streams.
 	for i := 0; i <= maxStreamID; i++ {
 		stream, err := s.Alloc()
 		if err != nil {
@@ -32,27 +32,6 @@ func TestDefaultStreamAllocatorAlloc(t *testing.T) {
 	// All streams are taken, we shouldn't be able to Alloc() another.
 	if _, err := s.Alloc(); err == nil {
 		t.Fatalf("allocating more than maxStreamID + 1 times in a row should fail")
-	}
-}
-
-func TestDefaultStreamAllocatorFree(t *testing.T) {
-	t.Parallel()
-	s := streamIDAllocator{}
-
-	allocated := make(map[frame.StreamID]struct{})
-
-	// Allocate all possible non-negative streams.
-	for i := 0; i <= maxStreamID; i++ {
-		stream, err := s.Alloc()
-		if err != nil {
-			t.Fatalf("unable to get stream %d", i)
-		}
-
-		if _, ok := allocated[stream]; ok {
-			t.Fatalf("got an already allocated stream %d", stream)
-		}
-
-		allocated[stream] = struct{}{}
 	}
 
 	// All streams are taken, so Alloc() after Free(x) should return streamID x.

--- a/transport/stream_test.go
+++ b/transport/stream_test.go
@@ -1,20 +1,69 @@
 package transport
 
 import (
-	"math/rand"
-
 	"scylla-go-driver/frame"
+	"testing"
 )
 
-// TestStreamIDAllocator is StreamIDAllocator that returns a random.
-type TestStreamIDAllocator struct{}
+var _ StreamIDAllocator = &DefaultStreamIDAllocator{}
 
-var _ StreamIDAllocator = TestStreamIDAllocator{}
+func TestDefaultStreamAllocatorAlloc(t *testing.T) {
+	t.Parallel()
+	s := DefaultStreamIDAllocator{}
 
-func (t TestStreamIDAllocator) Alloc() (frame.StreamID, error) {
-	const mask = int32(0xFFFF)
-	return frame.StreamID(rand.Int31() & mask), nil
+	allocated := make(map[frame.StreamID]struct{})
+
+	// Check if allocating all possible non-negative streams is possible.
+	for i := 0; i <= maxStreamID; i++ {
+		stream, err := s.Alloc()
+		if err != nil {
+			t.Fatalf("unable to get stream %d", i)
+		}
+
+		if _, ok := allocated[stream]; ok {
+			t.Fatalf("got an already allocated stream %d", stream)
+		}
+
+		if stream != frame.StreamID(i) {
+			t.Fatalf("expected stream %d, got stream %d", i, stream)
+		}
+
+		allocated[stream] = struct{}{}
+	}
+
+	// All streams are taken, we shouldn't be able to Alloc() another.
+	if _, err := s.Alloc(); err == nil {
+		t.Fatalf("allocating more than maxStreamID + 1 times in a row should fail")
+	}
 }
 
-func (t TestStreamIDAllocator) Free(id frame.StreamID) {
+func TestDefaultStreamAllocatorFree(t *testing.T) {
+	t.Parallel()
+	s := DefaultStreamIDAllocator{}
+
+	allocated := make(map[frame.StreamID]struct{})
+
+	// Allocate all possible non-negative streams.
+	for i := 0; i <= maxStreamID; i++ {
+		stream, err := s.Alloc()
+		if err != nil {
+			t.Fatalf("unable to get stream %d", i)
+		}
+
+		if _, ok := allocated[stream]; ok {
+			t.Fatalf("got an already allocated stream %d", stream)
+		}
+
+		allocated[stream] = struct{}{}
+	}
+
+	// All streams are taken, so Alloc() after Free(x) should return streamID x.
+	for key := range allocated {
+		s.Free(key)
+		if stream, err := s.Alloc(); err != nil {
+			t.Fatalf("failed to reacquire stream %d", stream)
+		} else if stream != key {
+			t.Fatalf("expected stream %d, got stream %d", stream, key)
+		}
+	}
 }

--- a/transport/stream_test.go
+++ b/transport/stream_test.go
@@ -5,11 +5,9 @@ import (
 	"testing"
 )
 
-var _ StreamIDAllocator = &DefaultStreamIDAllocator{}
-
 func TestDefaultStreamAllocatorAlloc(t *testing.T) {
 	t.Parallel()
-	s := DefaultStreamIDAllocator{}
+	s := streamIDAllocator{}
 
 	allocated := make(map[frame.StreamID]struct{})
 
@@ -39,7 +37,7 @@ func TestDefaultStreamAllocatorAlloc(t *testing.T) {
 
 func TestDefaultStreamAllocatorFree(t *testing.T) {
 	t.Parallel()
-	s := DefaultStreamIDAllocator{}
+	s := streamIDAllocator{}
 
 	allocated := make(map[frame.StreamID]struct{})
 


### PR DESCRIPTION
- moved getting streamID from sendRequest() to setHandler(), as a result
    setHandler() changed its return value to (frame.StreamId, err)
- moved stream from Conn to connReader so it's visible in sendRequest()
- added DefaultStreamIDAllocator ported directly from the rust driver
- removed TestStreamIDAllocator, replaced it with the new one in tests.

Fixes #108