### PR TITLE
Ml/dialing and opening connections

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,4 @@ services:
     command: ${SCYLLA_ARGS}
     ports:
       - "9042:9042"
+      - "19042:19042"

--- a/transport/conn.go
+++ b/transport/conn.go
@@ -8,7 +8,9 @@ import (
 	"log"
 	"net"
 	"runtime"
+	"strconv"
 	"sync"
+	"time"
 
 	"scylla-go-driver/frame"
 	. "scylla-go-driver/frame/request"
@@ -167,6 +169,8 @@ func (c *connReader) parse(op frame.OpCode) frame.Response {
 		return ParseError(&c.buf)
 	case frame.OpReady:
 		return ParseReady(&c.buf)
+	case frame.OpSupported:
+		return ParseSupported(&c.buf)
 	default:
 		log.Fatalf("not supported %d", op)
 		return nil
@@ -179,10 +183,63 @@ type Conn struct {
 	r    connReader
 }
 
+type ConnConfig struct {
+	TCPNoDelay bool
+	Timeout    time.Duration
+	// This will be used.
+	// DefaultConsistency frame.Consistency
+}
+
 const (
 	requestChanSize = 1024
 	ioBufferSize    = 8192
 )
+
+// OpenShardConn opens connection mapped to a specific shard on scylla node.
+func OpenShardConn(addr string, si ShardInfo, cfg ConnConfig) (*Conn, error) { // nolint:unused // This will be used.
+	it := ShardPortIterator(si)
+	maxTries := (maxPort-minPort+1)/int(si.NrShards) + 1
+	for i := 0; i < maxTries; i++ {
+		if conn, err := OpenLocalPortConn(addr, it(), cfg); err == nil {
+			return conn, nil
+		}
+	}
+
+	return nil, fmt.Errorf("failed to open connection on shard port: all local ports are busy")
+}
+
+// OpenLocalPortConn opens connection on a given local port.
+func OpenLocalPortConn(addr string, localPort uint16, cfg ConnConfig) (*Conn, error) {
+	// Not sure about local IP address. Empty IP and 172.19.0.1 works fine during tests but localhost does not.
+	// The problem is that when using localhost as IP connections are not mapped for appropriate shards
+	// even when using shard aware policy.
+	localAddr, err := net.ResolveTCPAddr("tcp", ":"+strconv.Itoa(int(localPort)))
+	if err != nil {
+		return nil, fmt.Errorf("resolving local TCP address: %w", err)
+	}
+
+	return OpenConn(addr, localAddr, cfg)
+}
+
+// OpenConn opens connection with specific local address.
+// In case lAddr is nil, random local address is chosen.
+func OpenConn(addr string, localAddr *net.TCPAddr, cfg ConnConfig) (*Conn, error) {
+	d := net.Dialer{
+		Timeout:   cfg.Timeout,
+		LocalAddr: localAddr,
+	}
+	conn, err := d.Dial("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("dialing TCP address %s: %w", addr, err)
+	}
+
+	tcpConn := conn.(*net.TCPConn)
+	if err = tcpConn.SetNoDelay(cfg.TCPNoDelay); err != nil {
+		return nil, fmt.Errorf("setting TCP no delay option: %w", err)
+	}
+
+	return WrapConn(tcpConn), nil
+}
 
 func WrapConn(conn net.Conn) *Conn {
 	c := &Conn{

--- a/transport/conn_integration_test.go
+++ b/transport/conn_integration_test.go
@@ -3,19 +3,29 @@
 package transport
 
 import (
-	"net"
-	"testing"
-
 	"scylla-go-driver/frame"
+	"testing"
 )
 
 func TestConnStartup(t *testing.T) {
-	nc, err := net.Dial("tcp", "localhost:9042")
+	//nc, err := net.Dial("tcp", "localhost:9042")
+	//if err != nil {
+	//	t.Fatal(err)
+	//}
+	//conn := WrapConn(nc, TestStreamIDAllocator{})
+
+	si := ShardInfo{
+		Shard:    1,
+		NrShards: 2, // Note that scylla node from docker-compose has only 2 shards.
+	}
+	// Similar problem as in OpenLocalPortConn where only some forms of local IP works fine with
+	// shard aware policy. I tested it manually using time.sleep() and checking if connection was
+	// mapped to appropriate shard with cqlsh ("SELECT * FROM system.clients;").
+	// Here only 172.19.0.2 IP ensures correct shard mapping.
+	conn, err := OpenShardConn("172.19.0.2:19042", si, ConnConfig{}, TestStreamIDAllocator{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	conn := WrapConn(nc)
-
 	opts := frame.StartupOptions{
 		"CQL_VERSION": "3.0.0",
 	}

--- a/transport/routing.go
+++ b/transport/routing.go
@@ -1,0 +1,39 @@
+package transport
+
+import "math/rand"
+
+const (
+	// Range of ports that can be used to establish connection.
+	maxPort = 65535
+	minPort = 49152
+)
+
+type ShardInfo struct {
+	Shard    uint16
+	NrShards uint16
+	// This will be used.
+	// MsbIgnore uint8
+}
+
+// RandomShardPort returns randomly generated port that can be used
+// to establish connection to a specific shard on scylla node.
+func RandomShardPort(si ShardInfo) uint16 {
+	maxRange := int(maxPort - si.NrShards + 1)
+	minRange := int(minPort + si.NrShards - 1)
+	r := uint16(rand.Intn(maxRange-minRange+1) + minRange)
+	return r/si.NrShards*si.NrShards + si.Shard
+}
+
+// ShardPortIterator returns iterator for consecutive ports that are
+// mapped to a specific shard on scylla node.
+func ShardPortIterator(si ShardInfo) func() uint16 {
+	port := RandomShardPort(si)
+
+	return func() uint16 {
+		port += si.NrShards
+		if port > maxPort {
+			port = (minPort+si.NrShards-1)/si.NrShards*si.NrShards + si.Shard
+		}
+		return port
+	}
+}


### PR DESCRIPTION
Transport: conn, created family of three OpenConn functions able to establish connection.
Transport: routing, added simple functions for randomly choosing specific kind of local port (Rust approach).

Fixes #104