### PR TITLE
Frame: Added ScyllaSupported

### DIFF
--- a/frame/response/supported.go
+++ b/frame/response/supported.go
@@ -1,6 +1,9 @@
 package response
 
 import (
+	"log"
+	"strconv"
+
 	"scylla-go-driver/frame"
 )
 
@@ -13,4 +16,75 @@ func ParseSupported(b *frame.Buffer) *Supported {
 	return &Supported{
 		Options: b.ReadStringMultiMap(),
 	}
+}
+
+func (s *Supported) ParseScyllaSupported() *frame.ScyllaSupported {
+	// This variable is filled during function
+	var si frame.ScyllaSupported
+
+	if s, ok := s.Options[frame.ScyllaShard]; ok {
+		if shard, err := strconv.ParseUint(s[0], 10, 16); err != nil {
+			if frame.Debug {
+				log.Printf("scylla: failed to parse %s value %v: %s", frame.ScyllaShard, s, err)
+			}
+		} else {
+			si.Shard = uint16(shard)
+		}
+	}
+	if s, ok := s.Options[frame.ScyllaNrShards]; ok {
+		if nrShards, err := strconv.ParseUint(s[0], 10, 16); err != nil {
+			if frame.Debug {
+				log.Printf("scylla: failed to parse %s value %v: %s", frame.ScyllaNrShards, s, err)
+			}
+		} else {
+			si.NrShards = uint16(nrShards)
+		}
+	}
+	if s, ok := s.Options[frame.ScyllaShardingIgnoreMSB]; ok {
+		if msbIgnore, err := strconv.ParseUint(s[0], 10, 8); err != nil {
+			if frame.Debug {
+				log.Printf("scylla: failed to parse %s value %v: %s", frame.ScyllaShardingIgnoreMSB, s, err)
+			}
+		} else {
+			si.MsbIgnore = uint8(msbIgnore)
+		}
+	}
+	if s, ok := s.Options[frame.ScyllaShardAwarePort]; ok {
+		if shardAwarePort, err := strconv.ParseUint(s[0], 10, 16); err != nil {
+			if frame.Debug {
+				log.Printf("scylla: failed to parse %s value %v: %s", frame.ScyllaShardAwarePort, s, err)
+			}
+		} else {
+			si.ShardAwarePort = uint16(shardAwarePort)
+		}
+	}
+	if s, ok := s.Options[frame.ScyllaShardAwarePortSSL]; ok {
+		if shardAwarePortSSL, err := strconv.ParseUint(s[0], 10, 16); err != nil {
+			if frame.Debug {
+				log.Printf("scylla: failed to parse %s value %v: %s", frame.ScyllaShardAwarePortSSL, s, err)
+			}
+		} else {
+			si.ShardAwarePortSSL = uint16(shardAwarePortSSL)
+		}
+	}
+
+	if s, ok := s.Options[frame.ScyllaPartitioner]; ok {
+		si.Partitioner = s[0]
+	}
+	if s, ok := s.Options[frame.ScyllaShardingAlgorithm]; ok {
+		si.ShardingAlgorithm = s[0]
+	}
+
+	// Currently, only one sharding algorithm is defined, and it is 'biased-token-round-robin'.
+	// For now we only support 'Murmur3Partitioner', it is due to change in the future.
+	if si.Partitioner != "org.apache.cassandra.dht.Murmur3Partitioner" ||
+		si.ShardingAlgorithm != "biased-token-round-robin" || si.NrShards == 0 || si.MsbIgnore == 0 {
+		if frame.Debug {
+			log.Printf(`scylla: unsupported sharding configuration, partitioner=%s, algorithm=%s, 
+						no_shards=%d, msb_ignore=%d`, si.Partitioner, si.ShardingAlgorithm, si.NrShards, si.MsbIgnore)
+		}
+		return &frame.ScyllaSupported{}
+	}
+
+	return &si
 }

--- a/frame/response/supported_test.go
+++ b/frame/response/supported_test.go
@@ -39,3 +39,59 @@ func TestSupportedEncodeDecode(t *testing.T) {
 		})
 	}
 }
+
+func TestParseScyllaSupported(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name     string
+		content  Supported
+		expected frame.ScyllaSupported
+	}{
+		{
+			name: "Smoke test",
+			content: Supported{frame.StringMultiMap{
+				frame.ScyllaNrShards:          []string{"52213"},
+				frame.ScyllaShardingIgnoreMSB: []string{"22"},
+				frame.ScyllaPartitioner:       []string{"org.apache.cassandra.dht.Murmur3Partitioner"},
+				frame.ScyllaShardingAlgorithm: []string{"biased-token-round-robin"},
+			}},
+			expected: frame.ScyllaSupported{
+				NrShards:          52213,
+				MsbIgnore:         22,
+				Partitioner:       "org.apache.cassandra.dht.Murmur3Partitioner",
+				ShardingAlgorithm: "biased-token-round-robin",
+			},
+		},
+		{
+			name: "All options",
+			content: Supported{frame.StringMultiMap{
+				frame.ScyllaShard:             []string{"3"},
+				frame.ScyllaNrShards:          []string{"12"},
+				frame.ScyllaShardingIgnoreMSB: []string{"22"},
+				frame.ScyllaPartitioner:       []string{"org.apache.cassandra.dht.Murmur3Partitioner"},
+				frame.ScyllaShardingAlgorithm: []string{"biased-token-round-robin"},
+				frame.ScyllaShardAwarePort:    []string{"19042"},
+				frame.ScyllaShardAwarePortSSL: []string{"19142"},
+			}},
+			expected: frame.ScyllaSupported{
+				Shard:             3,
+				NrShards:          12,
+				MsbIgnore:         22,
+				Partitioner:       "org.apache.cassandra.dht.Murmur3Partitioner",
+				ShardingAlgorithm: "biased-token-round-robin",
+				ShardAwarePort:    19042,
+				ShardAwarePortSSL: 19142,
+			},
+		},
+	}
+	for i := 0; i < len(testCases); i++ {
+		tc := testCases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out := tc.content.ParseScyllaSupported()
+			if diff := cmp.Diff(*out, tc.expected); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/frame/types.go
+++ b/frame/types.go
@@ -28,6 +28,29 @@ type Inet struct {
 	Port Int
 }
 
+// ScyllaSupported represents Scylla connection options as sent in SUPPORTED frame.
+// https://github.com/scylladb/scylla/blob/master/docs/design-notes/protocol-extensions.md#intranode-sharding
+type ScyllaSupported struct {
+	Shard             uint16
+	NrShards          uint16
+	MsbIgnore         uint8
+	Partitioner       string
+	ShardingAlgorithm string
+	ShardAwarePort    uint16
+	ShardAwarePortSSL uint16
+	LwtFlagMask       int
+}
+
+const (
+	ScyllaShard             = "SCYLLA_SHARD"
+	ScyllaNrShards          = "SCYLLA_NR_SHARDS"
+	ScyllaPartitioner       = "SCYLLA_PARTITIONER"
+	ScyllaShardingAlgorithm = "SCYLLA_SHARDING_ALGORITHM"
+	ScyllaShardingIgnoreMSB = "SCYLLA_SHARDING_IGNORE_MSB"
+	ScyllaShardAwarePort    = "SCYLLA_SHARD_AWARE_PORT"
+	ScyllaShardAwarePortSSL = "SCYLLA_SHARD_AWARE_PORT_SSL"
+)
+
 // https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L183-L201
 type OpCode = Byte
 


### PR DESCRIPTION
ScyllaSupported represents Scylla connection options as sent in SUPPORTED frame.
It will be used in f.e. PoolRefiller from issue #112.