### PR TITLE
experiments: Atomic load benchmark - atomic value vs unsafe pointer

### DIFF
--- a/experiments/atomicbenchmark_test.go
+++ b/experiments/atomicbenchmark_test.go
@@ -4,6 +4,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"unsafe"
+
+	uber "go.uber.org/atomic"
 )
 
 type data = map[string]int
@@ -34,6 +36,30 @@ func (u *up) load() data {
 	return *(*data)(atomic.LoadPointer(&u.v))
 }
 
+type uberUP struct {
+	v uber.UnsafePointer
+}
+
+func (u *uberUP) store(m data) {
+	u.v.Store(unsafe.Pointer(&m))
+}
+
+func (u *uberUP) load() data {
+	return *(*data)(u.v.Load())
+}
+
+type uberAV struct {
+	v uber.Value
+}
+
+func (u *uberAV) store(m data) {
+	u.v.Store(m)
+}
+
+func (u *uberAV) load() data {
+	return u.v.Load().(data)
+}
+
 func BenchmarkLoadAV(b *testing.B) {
 	var a av
 	d := make(data)
@@ -51,6 +77,36 @@ func BenchmarkLoadAV(b *testing.B) {
 
 func BenchmarkLoadUP(b *testing.B) {
 	var a up
+	d := make(data)
+	a.store(d)
+
+	var temp data
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		temp = a.load()
+	}
+
+	atomicResult = temp
+}
+
+func BenchmarkLoadUberAV(b *testing.B) {
+	var a uberAV
+	d := make(data)
+	a.store(d)
+
+	var temp data
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		temp = a.load()
+	}
+
+	atomicResult = temp
+}
+
+func BenchmarkLoadUberUP(b *testing.B) {
+	var a uberUP
 	d := make(data)
 	a.store(d)
 

--- a/experiments/atomicbenchmark_test.go
+++ b/experiments/atomicbenchmark_test.go
@@ -1,0 +1,65 @@
+package experiments
+
+import (
+	"sync/atomic"
+	"testing"
+	"unsafe"
+)
+
+type data = map[string]int
+
+var atomicResult data
+
+type av struct {
+	v atomic.Value
+}
+
+func (a *av) store(m data) {
+	a.v.Store(m)
+}
+
+func (a *av) load() data {
+	return a.v.Load().(data)
+}
+
+type up struct {
+	v unsafe.Pointer
+}
+
+func (u *up) store(m data) {
+	atomic.StorePointer(&u.v, unsafe.Pointer(&m))
+}
+
+func (u *up) load() data {
+	return *(*data)(atomic.LoadPointer(&u.v))
+}
+
+func BenchmarkLoadAV(b *testing.B) {
+	var a av
+	d := make(data)
+	a.store(d)
+
+	var temp data
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		temp = a.load()
+	}
+
+	atomicResult = temp
+}
+
+func BenchmarkLoadUP(b *testing.B) {
+	var a up
+	d := make(data)
+	a.store(d)
+
+	var temp data
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		temp = a.load()
+	}
+
+	atomicResult = temp
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module scylla-go-driver
 
 go 1.17
 
-require github.com/google/go-cmp v0.5.6
+require (
+	github.com/google/go-cmp v0.5.6
+	go.uber.org/atomic v1.9.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,14 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
+go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
I've benchmarked atomics which we will use in cluster. 
The winner is unsafe pointer.

Benchmark result:
goos: darwin
goarch: amd64
pkg: scylla-go-driver/experiments
cpu: Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
BenchmarkLoadAV
BenchmarkLoadAV-8   	691782937	         1.614 ns/op
BenchmarkLoadUP
BenchmarkLoadUP-8   	1000000000	         0.4589 ns/op
PASS