### PR TITLE
golangci: turned off default exclusions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -62,6 +62,11 @@ linters:
     - wsl
 
 issues:
+  exclude-use-default: false
   exclude:
+    - exported
     - indent-error-flow
     - should not use dot imports
+    - stdmethods
+    - ST1000
+


### PR DESCRIPTION
Turns out there was a hidden list of issues excluded by default. I turned it off, but errors reported by linter still have to be fixed. 