### PR TITLE
Transport: Pool, Conn: Added keyspace to conn and refiller

### DIFF
--- a/transport/pool.go
+++ b/transport/pool.go
@@ -120,8 +120,15 @@ type PoolRefiller struct {
 }
 
 func (r *PoolRefiller) init(addr string) error {
+	if err := r.cfg.validate(); err != nil {
+		return fmt.Errorf("config validate :%w", err)
+	}
+
 	conn, err := OpenConn(withDefaultPort(addr), nil, r.cfg)
 	if err != nil {
+		if conn != nil {
+			conn.Close()
+		}
 		return err
 	}
 
@@ -202,6 +209,9 @@ func (r *PoolRefiller) fill() {
 		conn, err := OpenShardConn(r.addr, si, r.cfg)
 		if err != nil {
 			log.Printf("failed to open shard conn: %s", err)
+			if conn != nil {
+				conn.Close()
+			}
 			continue
 		}
 		if conn.Shard() != i {

--- a/transport/query.go
+++ b/transport/query.go
@@ -29,6 +29,13 @@ func makeQueryForStatement(s Statement, pagingState frame.Bytes) Query {
 	}
 }
 
+func newStatementFromCQL(cql string) Statement {
+	return Statement{
+		Content:     cql,
+		Consistency: frame.ONE,
+	}
+}
+
 type QueryResult struct {
 	Rows        []frame.Row
 	Warnings    []string
@@ -45,7 +52,7 @@ func makeQueryResult(res frame.Response) (QueryResult, error) {
 			PagingState: v.Metadata.PagingState,
 			ColSpec:     v.Metadata.Columns,
 		}, nil
-	case *VoidResult, *SchemaChangeResult:
+	case *VoidResult, *SchemaChangeResult, *SetKeyspaceResult:
 		return QueryResult{}, nil
 	default:
 		return QueryResult{}, responseAsError(res)


### PR DESCRIPTION
- Added "IO" prefix to errors got by sendRequest caused by connection/internal error to differentiate them from other errors
- UseKeyspace can be called to try change keyspace of every present and future connection in connection pool

Fixes #153