### PR TITLE
transport: conn, fixed active waiting bug

### DIFF
--- a/transport/conn.go
+++ b/transport/conn.go
@@ -67,6 +67,8 @@ func (c *connWriter) loop() {
 		size := len(c.requestCh)
 		if size > maxCoalescedRequests {
 			size = maxCoalescedRequests
+		} else if size == 0 {
+			size = 1
 		}
 
 		for i := 0; i < size; i++ {


### PR DESCRIPTION
I think that setting size to at least 1 does the same job as waiting on channel before entering the inner loop, but it's more elegant 
and simpler.

Fixes #169 