### PR TITLE
transport: conn, add QueryAsync

### DIFF
--- a/transport/conn_integration_bench_test.go
+++ b/transport/conn_integration_bench_test.go
@@ -1,0 +1,55 @@
+//go:build integration
+
+package transport
+
+import (
+	"sync"
+	"testing"
+
+	"scylla-go-driver/frame"
+)
+
+var benchmarkConnQueryResult QueryResult
+
+func BenchmarkConnQueryIntegration(b *testing.B) {
+	h := newConnTestHelper(b)
+	h.applyFixture()
+	defer h.close()
+
+	query := Statement{Content: "SELECT * FROM mykeyspace.users", Consistency: frame.ONE}
+
+	var (
+		r   QueryResult
+		err error
+	)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		r, err = h.conn.Query(query, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	benchmarkConnQueryResult = r
+}
+
+func BenchmarkConnAsyncQueryIntegration(b *testing.B) {
+	h := newConnTestHelper(b)
+	h.applyFixture()
+	defer h.close()
+
+	query := Statement{Content: "SELECT * FROM mykeyspace.users", Consistency: frame.ONE}
+
+	var (
+		wg sync.WaitGroup
+		fn = func(fr QueryResult, err error) {
+			wg.Done()
+		}
+	)
+
+	b.ResetTimer()
+	wg.Add(b.N)
+	for n := 0; n < b.N; n++ {
+		h.conn.QueryAsync(query, nil, fn)
+	}
+	wg.Wait()
+}

--- a/transport/query.go
+++ b/transport/query.go
@@ -16,8 +16,8 @@ type Statement struct {
 	Compression       bool
 }
 
-func newQueryForStatement(s Statement, pagingState frame.Bytes) frame.Request {
-	return &Query{
+func makeQueryForStatement(s Statement, pagingState frame.Bytes) Query {
+	return Query{
 		Query:       s.Content,
 		Consistency: s.Consistency,
 		Options: frame.QueryOptions{


### PR DESCRIPTION
```
BenchmarkConnQueryIntegration-8             2233           2654839 ns/op            1251 B/op         34 allocs/op
BenchmarkConnAsyncQueryIntegration-8       10000           2088146 ns/op            1289 B/op         11 allocs/op
```

- QueryAsync runs Query in a separated goroutine
- Benchmarks moved to separate file
- connTestHelper added applyFixture
- requestChanSize increased to maxStreamID/2, with 1k goroutines block on putting to the channel
- newQueryForStatement changed to makeQueryForStatement returning Query this removes the gc pressure