### PR TITLE
Hg/cql as map

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.43
+          version: v1.45
 
       - name: Run tests
         run: make test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,9 +14,14 @@ jobs:
     name: Sanity check
     runs-on: ubuntu-latest
     steps:
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+          stable: true
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2

--- a/experiments/cqlasmapbenchmark_test.go
+++ b/experiments/cqlasmapbenchmark_test.go
@@ -1,0 +1,134 @@
+package experiments
+
+import (
+	"fmt"
+	"testing"
+
+	"scylla-go-driver/frame"
+)
+
+func CqlAsMap[K comparable, V any](c frame.CqlValue) (map[K]V, error) {
+	if c.Type.ID != frame.MapID {
+		return nil, fmt.Errorf("is not of map type")
+	}
+
+	keyType := c.Type.Map.Value.ID
+	valueType := c.Type.Map.Key.ID
+
+	var buf frame.Buffer
+	buf.Write(c.Value)
+
+	size := buf.ReadInt()
+
+	m := make(map[K]V, size)
+
+	var key interface{}
+	var value interface{}
+
+	for i := frame.Int(0); i < size; i++ {
+		switch keyType {
+		case frame.IntID:
+			key = buf.ReadInt()
+		default:
+			return nil, fmt.Errorf("unsupported key type")
+		}
+
+		switch valueType {
+		case frame.IntID:
+			value = buf.ReadInt()
+		default:
+			return nil, fmt.Errorf("unsupported value type")
+		}
+
+		if validKey, ok := key.(K); ok {
+			if validValue, ok2 := value.(V); ok2 {
+				m[validKey] = validValue
+				continue
+			}
+		}
+
+		return nil, fmt.Errorf("data can not be parsed to a specified type")
+	}
+
+	return m, buf.Error()
+}
+
+func CqlAsMapInt32Int32(c frame.CqlValue) (map[int32]int32, error) {
+	if c.Type.ID != frame.MapID {
+		return nil, fmt.Errorf("is not of map type")
+	}
+
+	if c.Type.Map.Key.ID != frame.IntID {
+		return nil, fmt.Errorf("invalid key type")
+	}
+
+	if c.Type.Map.Value.ID != frame.IntID {
+		return nil, fmt.Errorf("invalid value type")
+	}
+
+	var buf frame.Buffer
+	buf.Write(c.Value)
+
+	size := buf.ReadInt()
+
+	m := make(map[int32]int32, size)
+
+	for i := frame.Int(0); i < size; i++ {
+		key := buf.ReadInt()
+		value := buf.ReadInt()
+		m[key] = value
+	}
+
+	return m, buf.Error()
+}
+
+func mapint32int32AsCql(n int32) frame.CqlValue {
+	var buf frame.Buffer
+	buf.WriteInt(n)
+	for i := int32(1); i <= n; i++ {
+		buf.WriteInt(i)
+		buf.WriteInt(i)
+	}
+
+	return frame.CqlValue{
+		Type: &frame.Option{
+			ID:  frame.MapID,
+			Map: &frame.MapOption{Key: frame.Option{ID: frame.IntID}, Value: frame.Option{ID: frame.IntID}},
+		},
+		Value: buf.Bytes(),
+	}
+}
+
+var n int32 = 1000
+
+func BenchmarkGenericMapInt32Int32(b *testing.B) {
+	c := mapint32int32AsCql(n)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m, err := CqlAsMap[int32, int32](c)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		if int32(len(m)) != n {
+			b.Fatalf("invalid length %v", len(m))
+		}
+	}
+}
+
+func BenchmarkMapInt32Int32(b *testing.B) {
+	c := mapint32int32AsCql(n)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m, err := CqlAsMapInt32Int32(c)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		if int32(len(m)) != n {
+			b.Fatalf("invalid length %v", len(m))
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module scylla-go-driver
 
-go 1.17
+go 1.18
 
 require (
 	github.com/google/go-cmp v0.5.6


### PR DESCRIPTION
Wanted to see how bad generic solution to parse cql as map would be in comparison to strongly typed functions.
Here are the results:
```
go test ./cqlasmapbenchmark_test.go -bench=. -benchmem -benchtime=5s
goos: darwin
goarch: amd64
cpu: Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
BenchmarkGenericMapInt32Int32-8   	  103459	     60339 ns/op	   36097 B/op	    1498 allocs/op
BenchmarkMapInt32Int32-8          	  142498	     41311 ns/op	   30137 B/op	       8 allocs/op
PASS
```
Please let me know if you guys see some easy way to optimise it.