### PR TITLE
Changed package name to the importable one

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,7 +1,7 @@
 package scylla
 
 import (
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 )
 
 // See CQL Binary Protocol v4, section 9 for more details.

--- a/experiments/cqlasmapbenchmark_test.go
+++ b/experiments/cqlasmapbenchmark_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 )
 
 func CqlAsMap[K comparable, V any](c frame.CqlValue) (map[K]V, error) {

--- a/frame/request/authresponse.go
+++ b/frame/request/authresponse.go
@@ -1,7 +1,7 @@
 package request
 
 import (
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 )
 
 var _ frame.Request = (*AuthResponse)(nil)

--- a/frame/request/authresponse_test.go
+++ b/frame/request/authresponse_test.go
@@ -3,7 +3,7 @@ package request
 import (
 	"testing"
 
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/request/batch.go
+++ b/frame/request/batch.go
@@ -1,7 +1,7 @@
 package request
 
 import (
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 )
 
 const (

--- a/frame/request/batch_test.go
+++ b/frame/request/batch_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"testing"
 
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/request/execute.go
+++ b/frame/request/execute.go
@@ -1,7 +1,7 @@
 package request
 
 import (
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 )
 
 var _ frame.Request = (*Execute)(nil)

--- a/frame/request/execute_test.go
+++ b/frame/request/execute_test.go
@@ -3,7 +3,7 @@ package request
 import (
 	"testing"
 
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/request/options.go
+++ b/frame/request/options.go
@@ -1,7 +1,7 @@
 package request
 
 import (
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 )
 
 var _ frame.Request = (*Options)(nil)

--- a/frame/request/prepare.go
+++ b/frame/request/prepare.go
@@ -1,7 +1,7 @@
 package request
 
 import (
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 )
 
 var _ frame.Request = (*Prepare)(nil)

--- a/frame/request/prepare_test.go
+++ b/frame/request/prepare_test.go
@@ -3,7 +3,7 @@ package request
 import (
 	"testing"
 
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/request/query.go
+++ b/frame/request/query.go
@@ -1,7 +1,7 @@
 package request
 
 import (
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 )
 
 var _ frame.Request = (*Query)(nil)

--- a/frame/request/query_test.go
+++ b/frame/request/query_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/request/register.go
+++ b/frame/request/register.go
@@ -1,7 +1,7 @@
 package request
 
 import (
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 )
 
 var _ frame.Request = (*Register)(nil)

--- a/frame/request/register_test.go
+++ b/frame/request/register_test.go
@@ -3,7 +3,7 @@ package request
 import (
 	"testing"
 
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/request/startup.go
+++ b/frame/request/startup.go
@@ -1,7 +1,7 @@
 package request
 
 import (
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 )
 
 var _ frame.Request = (*Startup)(nil)

--- a/frame/request/startup_test.go
+++ b/frame/request/startup_test.go
@@ -3,7 +3,7 @@ package request
 import (
 	"testing"
 
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/response/authchallenge.go
+++ b/frame/response/authchallenge.go
@@ -1,7 +1,7 @@
 package response
 
 import (
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 )
 
 // AuthChallenge spec: https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L802

--- a/frame/response/authchallenge_test.go
+++ b/frame/response/authchallenge_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/response/authenticate.go
+++ b/frame/response/authenticate.go
@@ -1,7 +1,7 @@
 package response
 
 import (
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 )
 
 // Authenticate spec: https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L517

--- a/frame/response/authenticate_test.go
+++ b/frame/response/authenticate_test.go
@@ -3,7 +3,7 @@ package response
 import (
 	"testing"
 
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/response/authsuccess.go
+++ b/frame/response/authsuccess.go
@@ -1,7 +1,7 @@
 package response
 
 import (
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 )
 
 // AuthSuccess spec: https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L814

--- a/frame/response/authsuccess_test.go
+++ b/frame/response/authsuccess_test.go
@@ -3,7 +3,7 @@ package response
 import (
 	"testing"
 
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/response/error.go
+++ b/frame/response/error.go
@@ -3,7 +3,7 @@ package response
 import (
 	"fmt"
 
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 )
 
 // Error response message type used in non specified errors which don't have a body.

--- a/frame/response/error_test.go
+++ b/frame/response/error_test.go
@@ -3,7 +3,7 @@ package response
 import (
 	"testing"
 
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/response/event.go
+++ b/frame/response/event.go
@@ -2,7 +2,8 @@ package response
 
 import (
 	"log"
-	"scylla-go-driver/frame"
+
+	"github.com/mmatczuk/scylla-go-driver/frame"
 )
 
 // Event spec: https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L754

--- a/frame/response/event_test.go
+++ b/frame/response/event_test.go
@@ -3,7 +3,7 @@ package response
 import (
 	"testing"
 
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/response/ready.go
+++ b/frame/response/ready.go
@@ -1,7 +1,7 @@
 package response
 
 import (
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 )
 
 // Ready spec: https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L507

--- a/frame/response/result.go
+++ b/frame/response/result.go
@@ -2,7 +2,8 @@ package response
 
 import (
 	"log"
-	"scylla-go-driver/frame"
+
+	"github.com/mmatczuk/scylla-go-driver/frame"
 )
 
 // Result spec: https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L546

--- a/frame/response/result_test.go
+++ b/frame/response/result_test.go
@@ -3,7 +3,7 @@ package response
 import (
 	"github.com/google/go-cmp/cmp"
 
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 
 	"testing"
 )

--- a/frame/response/supported.go
+++ b/frame/response/supported.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"strconv"
 
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 )
 
 // Supported spec: https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L537

--- a/frame/response/supported_test.go
+++ b/frame/response/supported_test.go
@@ -3,7 +3,7 @@ package response
 import (
 	"testing"
 
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module scylla-go-driver
+module github.com/mmatczuk/scylla-go-driver
 
 go 1.18
 

--- a/query.go
+++ b/query.go
@@ -1,8 +1,8 @@
 package scylla
 
 import (
-	"scylla-go-driver/frame"
-	"scylla-go-driver/transport"
+	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/transport"
 )
 
 type Query struct {

--- a/session.go
+++ b/session.go
@@ -3,8 +3,8 @@ package scylla
 import (
 	"fmt"
 
-	"scylla-go-driver/frame"
-	"scylla-go-driver/transport"
+	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/transport"
 )
 
 // TODO: Add retry policy.

--- a/session_integration_test.go
+++ b/session_integration_test.go
@@ -5,7 +5,7 @@ package scylla
 import (
 	"testing"
 
-	"scylla-go-driver/transport"
+	"github.com/mmatczuk/scylla-go-driver/transport"
 )
 
 const TestHost = "192.168.100.100"

--- a/transport/cluster.go
+++ b/transport/cluster.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"time"
 
-	"scylla-go-driver/frame"
-	. "scylla-go-driver/frame/response"
+	"github.com/mmatczuk/scylla-go-driver/frame"
+	. "github.com/mmatczuk/scylla-go-driver/frame/response"
 
 	"go.uber.org/atomic"
 )

--- a/transport/cluster_integration_test.go
+++ b/transport/cluster_integration_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"scylla-go-driver/frame"
-	. "scylla-go-driver/frame/response"
+	"github.com/mmatczuk/scylla-go-driver/frame"
+	. "github.com/mmatczuk/scylla-go-driver/frame/response"
 )
 
 const awaitingChanges = 100 * time.Millisecond

--- a/transport/conn.go
+++ b/transport/conn.go
@@ -12,9 +12,9 @@ import (
 	"sync"
 	"time"
 
-	"scylla-go-driver/frame"
-	. "scylla-go-driver/frame/request"
-	. "scylla-go-driver/frame/response"
+	"github.com/mmatczuk/scylla-go-driver/frame"
+	. "github.com/mmatczuk/scylla-go-driver/frame/request"
+	. "github.com/mmatczuk/scylla-go-driver/frame/response"
 
 	"go.uber.org/atomic"
 )

--- a/transport/conn_integration_test.go
+++ b/transport/conn_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/transport/error.go
+++ b/transport/error.go
@@ -3,8 +3,8 @@ package transport
 import (
 	"fmt"
 
-	"scylla-go-driver/frame"
-	. "scylla-go-driver/frame/response"
+	"github.com/mmatczuk/scylla-go-driver/frame"
+	. "github.com/mmatczuk/scylla-go-driver/frame/response"
 )
 
 func responseAsError(res frame.Response) error {

--- a/transport/node.go
+++ b/transport/node.go
@@ -1,7 +1,7 @@
 package transport
 
 import (
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 
 	"go.uber.org/atomic"
 )

--- a/transport/pool.go
+++ b/transport/pool.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	. "scylla-go-driver/frame/response"
+	. "github.com/mmatczuk/scylla-go-driver/frame/response"
 
 	"go.uber.org/atomic"
 )

--- a/transport/query.go
+++ b/transport/query.go
@@ -1,9 +1,9 @@
 package transport
 
 import (
-	"scylla-go-driver/frame"
-	. "scylla-go-driver/frame/request"
-	. "scylla-go-driver/frame/response"
+	"github.com/mmatczuk/scylla-go-driver/frame"
+	. "github.com/mmatczuk/scylla-go-driver/frame/request"
+	. "github.com/mmatczuk/scylla-go-driver/frame/response"
 )
 
 type Statement struct {

--- a/transport/routing.go
+++ b/transport/routing.go
@@ -3,7 +3,7 @@ package transport
 import (
 	"math/rand"
 
-	"scylla-go-driver/transport/murmur"
+	"github.com/mmatczuk/scylla-go-driver/transport/murmur"
 )
 
 const (

--- a/transport/stream.go
+++ b/transport/stream.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"math/bits"
 
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 )
 
 const (

--- a/transport/stream_test.go
+++ b/transport/stream_test.go
@@ -3,7 +3,7 @@ package transport
 import (
 	"testing"
 
-	"scylla-go-driver/frame"
+	"github.com/mmatczuk/scylla-go-driver/frame"
 )
 
 func TestStreamIDAllocator(t *testing.T) {


### PR DESCRIPTION
For our driver to be usable (and benchmarkable) we need to import it from other golang projects.
This patch changed 'scylla-go-driver' main package name to 'github.com/mmatczuk/scylla-go-driver' by which other projects can import this driver.
I am merging to session branch because my benchmark uses session and it's the most convenient way for me.

Is it the prettiest way of doing it?
