### PR TITLE
transport: added support for authentication

### DIFF
--- a/.env
+++ b/.env
@@ -2,4 +2,4 @@ COMPOSE_PROJECT_NAME="scylla_go_driver"
 
 SCYLLA_IMAGE=scylladb/scylla
 SCYLLA_VERSION=4.6.1
-SCYLLA_ARGS="--smp 4 --memory 4G"
+SCYLLA_ARGS="--smp 4 --memory 4G" --authenticator PasswordAuthenticator"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: ^1.18.0
           stable: true
 
       - name: Run golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build:
 
 .PHONY: test
 test:
-	go test ./...
+	go test -run ^Test ./...
 
 .PHONY: test-no-cache
 test-no-cache:

--- a/frame/request/authresponse.go
+++ b/frame/request/authresponse.go
@@ -6,13 +6,16 @@ import (
 
 var _ frame.Request = (*AuthResponse)(nil)
 
-// AuthResponse spec: https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L311
+// AuthResponse currently only supports login and password authentication,
+// so it stores them instead of token for convenience.
+// Spec: https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L311
 type AuthResponse struct {
-	Token frame.Bytes
+	Username string
+	Password string
 }
 
 func (a *AuthResponse) WriteTo(b *frame.Buffer) {
-	b.WriteBytes(a.Token)
+	b.WriteLongString("\x00" + a.Username + "\x00" + a.Password)
 }
 
 func (*AuthResponse) OpCode() frame.OpCode {

--- a/frame/response/authchallenge_test.go
+++ b/frame/response/authchallenge_test.go
@@ -59,10 +59,6 @@ var dummyAC *AuthChallenge
 // We want to make sure that parsing does not crush driver even for random data.
 // We assign result to global variable to avoid compiler optimization.
 func FuzzAuthChallenge(f *testing.F) {
-	testCases := [][]byte{make([]byte, 1000000)}
-	for _, tc := range testCases {
-		f.Add(tc)
-	}
 	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
 		var buf frame.Buffer
 		buf.Write(data)

--- a/frame/response/authenticate_test.go
+++ b/frame/response/authenticate_test.go
@@ -43,10 +43,6 @@ var dummyA *Authenticate
 // We want to make sure that parsing does not crush driver even for random data.
 // We assign result to global variable to avoid compiler optimization.
 func FuzzAuthenticate(f *testing.F) {
-	testCases := [][]byte{make([]byte, 1000000)}
-	for _, tc := range testCases {
-		f.Add(tc)
-	}
 	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
 		var buf frame.Buffer
 		buf.Write(data)

--- a/frame/response/authsuccess_test.go
+++ b/frame/response/authsuccess_test.go
@@ -40,10 +40,6 @@ var dummyAS *AuthSuccess
 // We want to make sure that parsing does not crush driver even for random data.
 // We assign result to global variable to avoid compiler optimization.
 func FuzzAuthSuccess(f *testing.F) {
-	testCases := [][]byte{make([]byte, 1000000)}
-	for _, tc := range testCases {
-		f.Add(tc)
-	}
 	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
 		var buf frame.Buffer
 		buf.Write(data)

--- a/frame/response/error_test.go
+++ b/frame/response/error_test.go
@@ -331,10 +331,6 @@ var (
 // We want to make sure that parsing does not crush driver even for random data.
 // We assign result to global variable to avoid compiler optimization.
 func FuzzUnavailableError(f *testing.F) {
-	testCases := [][]byte{make([]byte, 1000000)}
-	for _, tc := range testCases {
-		f.Add(tc)
-	}
 	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
 		var buf frame.Buffer
 		buf.Write(data)
@@ -344,10 +340,6 @@ func FuzzUnavailableError(f *testing.F) {
 }
 
 func FuzzWriteTimeoutErrorError(f *testing.F) {
-	testCases := [][]byte{make([]byte, 1000000)}
-	for _, tc := range testCases {
-		f.Add(tc)
-	}
 	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
 		var buf frame.Buffer
 		buf.Write(data)
@@ -357,10 +349,6 @@ func FuzzWriteTimeoutErrorError(f *testing.F) {
 }
 
 func FuzzReadTimeoutError(f *testing.F) {
-	testCases := [][]byte{make([]byte, 1000000)}
-	for _, tc := range testCases {
-		f.Add(tc)
-	}
 	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
 		var buf frame.Buffer
 		buf.Write(data)
@@ -370,10 +358,6 @@ func FuzzReadTimeoutError(f *testing.F) {
 }
 
 func FuzzReadFailureErrorError(f *testing.F) {
-	testCases := [][]byte{make([]byte, 1000000)}
-	for _, tc := range testCases {
-		f.Add(tc)
-	}
 	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
 		var buf frame.Buffer
 		buf.Write(data)
@@ -383,10 +367,6 @@ func FuzzReadFailureErrorError(f *testing.F) {
 }
 
 func FuzzFuncFailureError(f *testing.F) {
-	testCases := [][]byte{make([]byte, 1000000)}
-	for _, tc := range testCases {
-		f.Add(tc)
-	}
 	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
 		var buf frame.Buffer
 		buf.Write(data)
@@ -396,10 +376,6 @@ func FuzzFuncFailureError(f *testing.F) {
 }
 
 func FuzzWriteFailureError(f *testing.F) {
-	testCases := [][]byte{make([]byte, 1000000)}
-	for _, tc := range testCases {
-		f.Add(tc)
-	}
 	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
 		var buf frame.Buffer
 		buf.Write(data)
@@ -409,10 +385,6 @@ func FuzzWriteFailureError(f *testing.F) {
 }
 
 func FuzzParseAlreadyExistsError(f *testing.F) {
-	testCases := [][]byte{make([]byte, 1000000)}
-	for _, tc := range testCases {
-		f.Add(tc)
-	}
 	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
 		var buf frame.Buffer
 		buf.Write(data)
@@ -422,10 +394,6 @@ func FuzzParseAlreadyExistsError(f *testing.F) {
 }
 
 func FuzzUnpreparedError(f *testing.F) {
-	testCases := [][]byte{make([]byte, 1000000)}
-	for _, tc := range testCases {
-		f.Add(tc)
-	}
 	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
 		var buf frame.Buffer
 		buf.Write(data)

--- a/frame/response/event_test.go
+++ b/frame/response/event_test.go
@@ -204,10 +204,6 @@ var (
 // We want to make sure that parsing does not crush driver even for random data.
 // We assign result to global variable to avoid compiler optimization.
 func FuzzStatusChange(f *testing.F) {
-	testCases := [][]byte{make([]byte, 1000000)}
-	for _, tc := range testCases {
-		f.Add(tc)
-	}
 	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
 		var buf frame.Buffer
 		buf.Write(data)
@@ -217,10 +213,6 @@ func FuzzStatusChange(f *testing.F) {
 }
 
 func FuzzTopologyChange(f *testing.F) {
-	testCases := [][]byte{make([]byte, 1000000)}
-	for _, tc := range testCases {
-		f.Add(tc)
-	}
 	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
 		var buf frame.Buffer
 		buf.Write(data)
@@ -230,10 +222,6 @@ func FuzzTopologyChange(f *testing.F) {
 }
 
 func FuzzSchemaChange(f *testing.F) {
-	testCases := [][]byte{make([]byte, 1000000)}
-	for _, tc := range testCases {
-		f.Add(tc)
-	}
 	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
 		var buf frame.Buffer
 		buf.Write(data)

--- a/frame/response/result_test.go
+++ b/frame/response/result_test.go
@@ -489,10 +489,6 @@ var (
 // We want to make sure that parsing does not crush driver even for random data.
 // We assign result to global variable to avoid compiler optimization.
 func FuzzRowsResult(f *testing.F) {
-	testCases := [][]byte{make([]byte, 1000000)}
-	for _, tc := range testCases {
-		f.Add(tc)
-	}
 	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
 		var buf frame.Buffer
 		buf.Write(data)
@@ -502,10 +498,6 @@ func FuzzRowsResult(f *testing.F) {
 }
 
 func FuzzSetKeyspaceResult(f *testing.F) {
-	testCases := [][]byte{make([]byte, 1000000)}
-	for _, tc := range testCases {
-		f.Add(tc)
-	}
 	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
 		var buf frame.Buffer
 		buf.Write(data)
@@ -515,10 +507,6 @@ func FuzzSetKeyspaceResult(f *testing.F) {
 }
 
 func FuzzPreparedResult(f *testing.F) {
-	testCases := [][]byte{make([]byte, 1000000)}
-	for _, tc := range testCases {
-		f.Add(tc)
-	}
 	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
 		var buf frame.Buffer
 		buf.Write(data)
@@ -528,10 +516,6 @@ func FuzzPreparedResult(f *testing.F) {
 }
 
 func FuzzSchemaChangeResultResult(f *testing.F) {
-	testCases := [][]byte{make([]byte, 1000000)}
-	for _, tc := range testCases {
-		f.Add(tc)
-	}
 	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
 		var buf frame.Buffer
 		buf.Write(data)

--- a/frame/response/supported_test.go
+++ b/frame/response/supported_test.go
@@ -101,10 +101,6 @@ var dummyS *Supported
 // We want to make sure that parsing does not crush driver even for random data.
 // We assign result to global variable to avoid compiler optimization.
 func FuzzSupported(f *testing.F) {
-	testCases := [][]byte{make([]byte, 1000000)}
-	for _, tc := range testCases {
-		f.Add(tc)
-	}
 	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
 		var buf frame.Buffer
 		buf.Write(data)

--- a/transport/cluster_integration_test.go
+++ b/transport/cluster_integration_test.go
@@ -33,14 +33,13 @@ func compareNodes(c *Cluster, addr string, expected *Node) error {
 }
 
 func TestClusterIntegration(t *testing.T) {
-	cfg := ConnConfig{Timeout: 250 * time.Millisecond}
 	addr := frame.Inet{
 		IP:   []byte{192, 168, 100, 100},
 		Port: 9042,
 	}
 
 	// There is no one listening at the first address, it just checks cluster proper behavior.
-	c, err := NewCluster(cfg, []string{frame.StatusChange}, "123.123.123.123:1234", TestHost+":9042")
+	c, err := NewCluster(dummyConnConfig, []string{frame.StatusChange}, "123.123.123.123:1234", TestHost+":9042")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/transport/conn_integration_test.go
+++ b/transport/conn_integration_test.go
@@ -13,13 +13,19 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+var dummyConnConfig = ConnConfig{
+	Username: "cassandra",
+	Password: "cassandra",
+	Timeout:  250 * time.Millisecond,
+}
+
 func TestOpenShardConnIntegration(t *testing.T) {
 	si := ShardInfo{
 		Shard:    1,
 		NrShards: 2, // Scylla node from docker-compose has only 2 shards
 	}
 
-	c, err := OpenShardConn(TestHost+":19042", si, ConnConfig{Timeout: 500 * time.Millisecond})
+	c, err := OpenShardConn(TestHost+":19042", si, dummyConnConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +41,7 @@ type connTestHelper struct {
 }
 
 func newConnTestHelper(t testing.TB) *connTestHelper {
-	conn, err := OpenConn(TestHost+":9042", nil, ConnConfig{Timeout: 500 * time.Millisecond})
+	conn, err := OpenConn(TestHost+":9042", nil, dummyConnConfig)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/transport/pool_integration_test.go
+++ b/transport/pool_integration_test.go
@@ -10,8 +10,8 @@ import (
 
 const refillerBackoff = 500 * time.Millisecond
 
-func newTestConnPool(t *testing.T, cfg ConnConfig) *ConnPool {
-	p, err := NewConnPool(TestHost, cfg)
+func newTestConnPool(t *testing.T) *ConnPool {
+	p, err := NewConnPool(TestHost, dummyConnConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,7 +30,7 @@ func newTestConnPool(t *testing.T, cfg ConnConfig) *ConnPool {
 }
 
 func TestConnPoolIntegration(t *testing.T) {
-	p := newTestConnPool(t, ConnConfig{})
+	p := newTestConnPool(t)
 
 	t.Log("Close connections")
 	for _, c := range p.AllConns() {
@@ -60,7 +60,7 @@ func TestConnPoolIntegration(t *testing.T) {
 }
 
 func TestConnPoolConnIntegration(t *testing.T) {
-	p := newTestConnPool(t, ConnConfig{})
+	p := newTestConnPool(t)
 	defer p.Close()
 
 	t0 := MurmurToken([]byte(""))


### PR DESCRIPTION
In gocql and rust they only supported  **PasswordAuthenticator** and used it no matter what approved authenticator was sent in **Authenticate** response.
Do we also only care for this one?

Fixes #105
