### PR TITLE
transport: reusing response handlers

### DIFF
--- a/session.go
+++ b/session.go
@@ -54,16 +54,18 @@ var (
 		"SERIAL      Consistency = 0x0008\n" +
 		"LOCALSERIAL Consistency = 0x0009\n" +
 		"LOCALONE    Consistency = 0x000A")
-	errNoConnection = fmt.Errorf("no working connection")
+	errNoConnection   = fmt.Errorf("no working connection")
+	errNoPreallocated = fmt.Errorf("preallocated handlers size must be greater than 0")
 )
 
 func DefaultSessionConfig(hosts ...string) SessionConfig {
 	return SessionConfig{
 		Hosts: hosts,
 		ConnConfig: transport.ConnConfig{
-			Timeout:            500 * time.Millisecond,
-			TCPNoDelay:         true,
-			DefaultConsistency: LOCALQUORUM,
+			Timeout:              500 * time.Millisecond,
+			TCPNoDelay:           true,
+			DefaultConsistency:   LOCALQUORUM,
+			PreallocatedHandlers: 16000,
 		},
 	}
 }
@@ -93,6 +95,9 @@ func (cfg *SessionConfig) Validate() error {
 	}
 	if cfg.DefaultConsistency > LOCALONE {
 		return ErrConsistency
+	}
+	if cfg.PreallocatedHandlers == 0 {
+		return errNoPreallocated
 	}
 
 	return nil

--- a/transport/responsehandler.go
+++ b/transport/responsehandler.go
@@ -1,0 +1,39 @@
+package transport
+
+type responseHandler chan response
+
+const responseHandlerSize = 2
+
+type responseHandlerAllocator struct {
+	handlers []responseHandler
+	size     uint
+	idx      uint
+}
+
+func makeResponseHandlerAllocator(size uint) responseHandlerAllocator {
+	return responseHandlerAllocator{
+		handlers: make([]responseHandler, size),
+		size:     size,
+		idx:      0,
+	}
+}
+
+// alloc reuses previously allocated handler or allocates new one.
+func (r *responseHandlerAllocator) alloc() responseHandler {
+	if r.idx > 0 {
+		r.idx--
+		return r.handlers[r.idx]
+	}
+
+	return make(responseHandler, responseHandlerSize)
+}
+
+// yield puts used handler back.
+// After calling the ownership of responseHandler is passed to responseHandlerAllocator.
+// If there is no room to store handler it is dropped.
+func (r *responseHandlerAllocator) yield(h responseHandler) {
+	if r.idx < r.size {
+		r.handlers[r.idx] = h
+		r.idx++
+	}
+}


### PR DESCRIPTION
- ResponseHandlersAllocator reuses already allocated handlers or allocates new one. 
- Default allocated handlers size was chosen to be 16000 ~ half of all the streamIDs
- Modified connConfig struct to store PreallocatedHandlers size.
- There is no need to drain the handlers. Once the error occurs connection will be closed and channel size is 2, so this will not block.  
