### PR TITLE
frame: added fuzzing for tests

### DIFF
--- a/frame/buffer_fuzz_test.go
+++ b/frame/buffer_fuzz_test.go
@@ -1,0 +1,202 @@
+package frame
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// Fuzzing tests are based on:
+//   - data            == deserialize(serialize(data))
+//   - serialize(data) == serialize(deserialize(serialize(data)))
+// with the exception of comparing serialized maps, which is nondeterministic because of
+// nondeterministic iteration over build-in map.
+//
+// command to use fuzzing: go test -fuzz=XXX -fuzztime 30s
+// where XXX is unambiguous fuzz test name.
+
+func FuzzBufferByte(f *testing.F) { // nolint:dupl // Tests are different.
+	testCases := []Byte{0, 22, 125, 255}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, in Byte) { // nolint:thelper // This is not a helper function.
+		var buf Buffer
+		buf.WriteByte(in)
+		inBuf := make([]byte, len(buf.Bytes()))
+		copy(inBuf, buf.Bytes())
+		out := buf.ReadByte()
+		if in != out || buf.Error() != nil {
+			t.Errorf("in: %v, out: %v, err: %v", in, out, buf.Error())
+		}
+		buf.WriteByte(out)
+		outBuf := buf.Bytes()
+		if diff := cmp.Diff(inBuf, outBuf); diff != "" || buf.Error() != nil {
+			t.Errorf("inBuff: %v, outBuff: %v, err: %v", inBuf, outBuf, buf.Error())
+		}
+	})
+}
+
+func FuzzBufferShort(f *testing.F) { // nolint:dupl // Tests are different.
+	testCases := []Short{0, 245, 42995, 65535}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, in Short) { // nolint:thelper // This is not a helper function.
+		var buf Buffer
+		buf.WriteShort(in)
+		inBuf := make([]byte, len(buf.Bytes()))
+		copy(inBuf, buf.Bytes())
+		out := buf.ReadShort()
+		if in != out || buf.Error() != nil {
+			t.Errorf("in: %v, out: %v, err: %v", in, out, buf.Error())
+		}
+		buf.WriteShort(out)
+		outBuf := buf.Bytes()
+		if diff := cmp.Diff(inBuf, outBuf); diff != "" || buf.Error() != nil {
+			t.Errorf("inBuff: %v, outBuff: %v, err: %v", inBuf, outBuf, buf.Error())
+		}
+	})
+}
+
+func FuzzBufferInt(f *testing.F) {
+	testCases := []Int{-2147483648, 0, 1, 9452, 123335, 2147483647}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, in Int) { // nolint:thelper // This is not a helper function.
+		var buf Buffer
+		buf.WriteInt(in)
+		inBuf := make([]byte, len(buf.Bytes()))
+		copy(inBuf, buf.Bytes())
+		out := buf.ReadInt()
+		if in != out || buf.Error() != nil {
+			t.Errorf("in: %v, out: %v, err: %v", in, out, buf.Error())
+		}
+		buf.WriteInt(out)
+		outBuf := buf.Bytes()
+		if diff := cmp.Diff(inBuf, outBuf); diff != "" || buf.Error() != nil {
+			t.Errorf("inBuff: %v, outBuff: %v, err: %v", inBuf, outBuf, buf.Error())
+		}
+	})
+}
+
+func FuzzBufferString(f *testing.F) { // nolint:dupl // Tests are different.
+	testCases := []string{"a", "golang", "πœę©ß", ""}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, in string) { // nolint:thelper // This is not a helper function.
+		var buf Buffer
+		buf.WriteString(in)
+		inBuf := make([]byte, len(buf.Bytes()))
+		copy(inBuf, buf.Bytes())
+		out := buf.ReadString()
+		if in != out || buf.Error() != nil {
+			t.Errorf("in: %v, out: %v, err: %v", in, out, buf.Error())
+		}
+		buf.WriteString(out)
+		outBuf := buf.Bytes()
+		if diff := cmp.Diff(inBuf, outBuf); diff != "" || buf.Error() != nil {
+			t.Errorf("inBuff: %v, outBuff: %v, err: %v", inBuf, outBuf, buf.Error())
+		}
+	})
+}
+
+func FuzzBufferStringList(f *testing.F) {
+	testCases := [][3]string{{"a", "", ""}, {"a", "b", ""}}
+	for _, tc := range testCases {
+		f.Add(tc[0], tc[1], tc[2])
+	}
+	f.Fuzz(func(t *testing.T, a, b, c string) { // nolint:thelper // This is not a helper function.
+		in := StringList{a, b, c}
+		var buf Buffer
+		buf.WriteStringList(in)
+		inBuf := make([]byte, len(buf.Bytes()))
+		copy(inBuf, buf.Bytes())
+		out := buf.ReadStringList()
+		if diff := cmp.Diff(in, out); diff != "" || buf.Error() != nil {
+			t.Errorf("in: %v, out: %v, err: %v", in, out, buf.Error())
+		}
+		buf.WriteStringList(out)
+		outBuf := buf.Bytes()
+		if diff := cmp.Diff(inBuf, outBuf); diff != "" || buf.Error() != nil {
+			t.Errorf("inBuff: %v, outBuff: %v, err: %v", inBuf, outBuf, buf.Error())
+		}
+	})
+}
+
+func FuzzBufferStringMultiMap(f *testing.F) {
+	testCases := [][5]string{{"k1", "v11", "v12", "k2", "v2"}}
+	for _, tc := range testCases {
+		f.Add(tc[0], tc[1], tc[2], tc[3], tc[4])
+	}
+	f.Fuzz(func(t *testing.T, k1, v11, v12, k2, v2 string) { // nolint:thelper // This is not a helper function.
+		in := StringMultiMap{k1: {v11, v12}, k2: {v2}}
+		var buf Buffer
+		buf.WriteStringMultiMap(in)
+		out := buf.ReadStringMultiMap()
+		if diff := cmp.Diff(in, out); diff != "" || buf.Error() != nil {
+			t.Errorf("in: %v, out: %v, err: %v", in, out, buf.Error())
+		}
+	})
+}
+
+func FuzzBufferUUID(f *testing.F) {
+	testCases := []UUID{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}}
+	for _, tc := range testCases {
+		f.Add(tc[:])
+	}
+	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
+		var in UUID
+		var buf Buffer
+		copy(in[:], data)
+		buf.WriteUUID(in)
+		inBuf := make([]byte, len(buf.Bytes()))
+		copy(inBuf, buf.Bytes())
+		out := buf.ReadUUID()
+		if diff := cmp.Diff(in, out); diff != "" || buf.Error() != nil {
+			t.Errorf("in: %v, out: %v, err: %v", in, out, buf.Error())
+		}
+		buf.WriteUUID(out)
+		outBuf := buf.Bytes()
+		if diff := cmp.Diff(inBuf, outBuf); diff != "" || buf.Error() != nil {
+			t.Errorf("inBuff: %v, outBuff: %v, err: %v", inBuf, outBuf, buf.Error())
+		}
+	})
+}
+
+func FuzzBufferHeader(f *testing.F) {
+	testCases := []Header{{
+		Version:  CQLv4,
+		Flags:    0,
+		StreamID: 0,
+		OpCode:   OpSupported,
+		Length:   0,
+	}}
+	for _, tc := range testCases {
+		f.Add(tc.Version, tc.Flags, tc.StreamID, tc.OpCode, tc.Length)
+	}
+	f.Fuzz(func(t *testing.T, v, f byte, s int16, o byte, l int32) { // nolint:thelper // This is not a helper function.
+		in := Header{
+			Version:  v,
+			Flags:    f,
+			StreamID: s,
+			OpCode:   o,
+			Length:   l,
+		}
+		var buf Buffer
+		in.WriteTo(&buf)
+		inBuf := make([]byte, len(buf.Bytes()))
+		copy(inBuf, buf.Bytes())
+		out := ParseHeader(&buf)
+		if diff := cmp.Diff(in, out); diff != "" || buf.Error() != nil {
+			t.Errorf("in: %+#v, out: %+#v, err: %v", in, out, buf.Error())
+		}
+		out.WriteTo(&buf)
+		outBuf := buf.Bytes()
+		if diff := cmp.Diff(inBuf, outBuf); diff != "" || buf.Error() != nil {
+			t.Errorf("inBuff: %v, outBuff: %v, err: %v", inBuf, outBuf, buf.Error())
+		}
+	})
+}

--- a/frame/buffer_read.go
+++ b/frame/buffer_read.go
@@ -39,8 +39,20 @@ func (b *Buffer) readInto(p []byte) {
 	}
 }
 
+const maxSliceSize int = 128_000_000
+
 // readCopy reads next n bytes from the buffer, and returns a copy.
 func (b *Buffer) readCopy(n int) Bytes {
+	// Here n can be corrupted, so we have to check for that before allocating
+	// potentially enormously big slice.
+	if b.readErr != nil {
+		return nil
+	}
+	if n > maxSliceSize {
+		b.readErr = fmt.Errorf("too big slice size: %v", n)
+		return nil
+	}
+
 	p := make(Bytes, n)
 	b.readInto(p)
 	return p

--- a/frame/buffer_read_test.go
+++ b/frame/buffer_read_test.go
@@ -159,7 +159,7 @@ func TestBufferReadStringMultiMap(t *testing.T) {
 	}
 }
 
-func TestBuffer_ReadUUID(t *testing.T) {
+func TestBufferReadUUID(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
 		name     string

--- a/frame/buffer_write_test.go
+++ b/frame/buffer_write_test.go
@@ -158,7 +158,7 @@ func TestBufferWriteStringMultiMap(t *testing.T) {
 	}
 }
 
-func TestBuffer_WriteUUID(t *testing.T) {
+func TestBufferWriteUUID(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
 		name     string

--- a/frame/cqlvalue.go
+++ b/frame/cqlvalue.go
@@ -162,7 +162,7 @@ func (c CqlValue) AsIP() (net.IP, error) {
 		return nil, fmt.Errorf("invalid ip length")
 	}
 
-	return net.IP(c.Value), nil
+	return c.Value, nil
 }
 
 func (c CqlValue) AsFloat32() (float32, error) {

--- a/frame/cqlvalue_test.go
+++ b/frame/cqlvalue_test.go
@@ -909,3 +909,239 @@ func TestCqlValueStringMap(t *testing.T) {
 		})
 	}
 }
+
+// Fuzzing tests are based on: data == deserialize(serialize(data))
+// We are trying to fuzz only correct data, so that the process of serialization
+// and deserialization can be a good indicator of correctness.
+// Fuzzing random data is done inside request/response packages
+// (they are the points of communication with outer, potentially random world), where parsing functions
+// are using helpers (like those that are tested here) that are being tested as well.
+
+func FuzzCqlValueASCII(f *testing.F) {
+	testCases := []string{"Hello World!", ""}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data string) { // nolint:thelper // This is not a helper function.
+		in := CqlValue{
+			Type:  &Option{ID: ASCIIID},
+			Value: []byte(data),
+		}
+		ascii, err := in.AsASCII()
+		if err != nil {
+			// We skip tests with incorrect CqlValue.
+			t.Skip()
+		}
+		out, err := CqlFromASCII(ascii)
+		if err != nil {
+			t.Errorf("cannot deserialize serialized data: %v", err)
+		}
+		if diff := cmp.Diff(in, out); diff != "" {
+			t.Errorf("in: %v, out: %v", in, out)
+		}
+	})
+}
+
+func FuzzCqlValueBlob(f *testing.F) {
+	testCases := [][]byte{[]byte("Hello World!"), []byte("")}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
+		in := CqlValue{
+			Type:  &Option{ID: BlobID},
+			Value: data,
+		}
+		x, err := in.AsBlob()
+		if err != nil {
+			// We skip tests with incorrect CqlValue.
+			t.Skip()
+		}
+		out := CqlFromBlob(x)
+		if diff := cmp.Diff(in, out); diff != "" {
+			t.Errorf("in: %v, out: %v", in, out)
+		}
+	})
+}
+
+func FuzzCqlValueInt32(f *testing.F) {
+	testCases := []int32{0x01020304, 0, 0xbeefed, -0xbeefed, math.MinInt32, math.MaxInt32}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data int32) { // nolint:thelper // This is not a helper function.
+		in := CqlFromInt32(data)
+		x, err := in.AsInt32()
+		if err != nil {
+			t.Errorf("cannot deserialize serialized data: %v", err)
+		}
+		out := CqlFromInt32(x)
+		if diff := cmp.Diff(in, out); diff != "" {
+			t.Errorf("in: %v, out: %v", in, out)
+		}
+	})
+}
+
+func FuzzCqlValueInt64(f *testing.F) {
+	testCases := []int64{0x0102030405060708, 0, 0xdeadbeefcafe, -0xdeadbeefcafe, math.MinInt64, math.MaxInt64}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data int64) { // nolint:thelper // This is not a helper function.
+		in := CqlFromInt64(data)
+		x, err := in.AsInt64()
+		if err != nil {
+			t.Errorf("cannot deserialize serialized data: %v", err)
+		}
+		out := CqlFromInt64(x)
+		if diff := cmp.Diff(in, out); diff != "" {
+			t.Errorf("in: %v, out: %v", in, out)
+		}
+	})
+}
+
+func FuzzCqlValueInt16(f *testing.F) {
+	testCases := []int16{0x0102, 0, 15, -15, math.MinInt16, math.MaxInt16}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data int16) { // nolint:thelper // This is not a helper function.
+		in := CqlFromInt16(data)
+		x, err := in.AsInt16()
+		if err != nil {
+			t.Errorf("cannot deserialize serialized data: %v", err)
+		}
+		out := CqlFromInt16(x)
+		if diff := cmp.Diff(in, out); diff != "" {
+			t.Errorf("in: %v, out: %v", in, out)
+		}
+	})
+}
+
+func FuzzCqlValueText(f *testing.F) {
+	testCases := []string{"Hello World!", "", "½²=¼: Hello, 世界!"}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data string) { // nolint:thelper // This is not a helper function.
+		in, err := CqlFromText(data)
+		if err != nil {
+			// We skip tests with incorrect CqlValue.
+			t.Skip()
+		}
+		x, err := in.AsText()
+		if err != nil {
+			t.Errorf("cannot deserialize serialized data: %v", err)
+		}
+		out, err := CqlFromText(x)
+		if err != nil {
+			t.Errorf("second deserialization failed: %v", err)
+		}
+		if diff := cmp.Diff(in, out); diff != "" {
+			t.Errorf("in: %v, out: %v", in, out)
+		}
+	})
+}
+
+func FuzzCqlValueIP(f *testing.F) {
+	testCases := [][]byte{{1, 2, 3}, net.IP{127, 0, 0, 1}, net.IP{127, 0, 0, 1}.To16()}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
+		in, err := CqlFromIP(data)
+		if err != nil {
+			// We skip tests with incorrect CqlValue.
+			t.Skip()
+		}
+		x, err := in.AsIP()
+		if err != nil {
+			t.Errorf("cannot deserialize serialized data: %v", err)
+		}
+		out, err := CqlFromIP(x)
+		if err != nil {
+			t.Errorf("second deserialization failed: %v", err)
+		}
+		if diff := cmp.Diff(in, out); diff != "" {
+			t.Errorf("in: %v, out: %v", in, out)
+		}
+	})
+}
+
+func FuzzCqlValueFloat32(f *testing.F) {
+	testCases := []float32{0, 1.5e30, -1.5e30, math.SmallestNonzeroFloat32, math.MaxFloat32}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data float32) { // nolint:thelper // This is not a helper function.
+		in := CqlFromFloat32(data)
+		x, err := in.AsFloat32()
+		if err != nil {
+			t.Errorf("cannot deserialize serialized data: %v", err)
+		}
+		out := CqlFromFloat32(x)
+		if diff := cmp.Diff(in, out); diff != "" {
+			t.Errorf("in: %v, out: %v", in, out)
+		}
+	})
+}
+
+func FuzzCqlValueFloat64(f *testing.F) {
+	testCases := []float64{0, 1.5e120, -1.5e120, math.SmallestNonzeroFloat64, math.MaxFloat64}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data float64) { // nolint:thelper // This is not a helper function.
+		in := CqlFromFloat64(data)
+		x, err := in.AsFloat64()
+		if err != nil {
+			t.Errorf("cannot deserialize serialized data: %v", err)
+		}
+		out := CqlFromFloat64(x)
+		if diff := cmp.Diff(in, out); diff != "" {
+			t.Errorf("in: %v, out: %v", in, out)
+		}
+	})
+}
+
+func FuzzCqlValueStringSlice(f *testing.F) {
+	testCases := [][4]string{{"1234567890", "rust", "cohle", "𝒽𝗲ɬł० ω𝒐ṙḹ𝖉"}, {"1234567890", "rust", "cohle", "Hello World!"}}
+	for _, tc := range testCases {
+		f.Add(tc[0], tc[1], tc[2], tc[3])
+	}
+	f.Fuzz(func(t *testing.T, a, b, c, d string) { // nolint:thelper // This is not a helper function.
+		in := []string{a, b, c, d}
+		cv := CqlValue{
+			Type: &Option{
+				ID:   ListID,
+				List: &ListOption{Element: Option{ID: VarcharID}},
+			},
+			Value: stringSliceToBytes(in),
+		}
+		out, err := cv.AsStringSlice()
+		if err != nil {
+			t.Errorf("cannot deserialize serialized data: %v", err)
+		}
+		if diff := cmp.Diff(in, out); diff != "" {
+			t.Errorf("in: %v, out: %v", in, out)
+		}
+	})
+}
+
+func FuzzCqlValueStringMap(f *testing.F) {
+	testCases := [][6]string{{"rust", "cohle", "hello", "world", "dead", "beef"}}
+	for _, tc := range testCases {
+		f.Add(tc[0], tc[1], tc[2], tc[3], tc[4], tc[5])
+	}
+	f.Fuzz(func(t *testing.T, a, b, c, d, e, f string) { // nolint:thelper // This is not a helper function.
+		in := map[string]string{a: b, c: d, e: f}
+		cv := cqlStringMap(in, VarcharID, VarcharID)
+		out, err := cv.AsStringMap()
+		if err != nil {
+			t.Errorf("cannot deserialize serialized data: %v", err)
+		}
+		if diff := cmp.Diff(in, out); diff != "" {
+			t.Errorf("in: %v, out: %v", in, out)
+		}
+	})
+}

--- a/frame/request/authresponse_test.go
+++ b/frame/request/authresponse_test.go
@@ -34,3 +34,19 @@ func TestAuthResponseWriteTo(t *testing.T) {
 		})
 	}
 }
+
+// We want to make sure that parsing does not crush driver even for random data.
+func FuzzAuthResponse(f *testing.F) {
+	testCases := [][]byte{{0xca, 0xfe, 0xba, 0xbe}}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, token []byte) { // nolint:thelper // This is not a helper function.
+		in := AuthResponse{Token: token}
+		var buf frame.Buffer
+		in.WriteTo(&buf)
+		if buf.Error() != nil {
+			t.Error(buf.Error())
+		}
+	})
+}

--- a/frame/request/batch_test.go
+++ b/frame/request/batch_test.go
@@ -99,3 +99,29 @@ func TestBatch(t *testing.T) {
 		})
 	}
 }
+
+// We want to make sure that parsing does not crush driver even for random data.
+func FuzzBatch(f *testing.F) {
+	f.Fuzz(func(t *testing.T, b1, b2, b3 byte, si1, si2 uint16, i1, i2 int32, li1 int64, s1, s2, s3 string, bs1, bs2, bs3 []byte) { // nolint:thelper // This is not a helper function.
+		x := BatchQuery{
+			Kind:     b1,
+			Query:    s1,
+			Prepared: bs1,
+			Names:    frame.StringList{s2, s3},
+			Values:   []frame.Value{{N: i1, Bytes: bs2}, {N: i2, Bytes: bs3}},
+		}
+		in := Batch{
+			Type:              b2,
+			Flags:             b3,
+			Queries:           []BatchQuery{x, x},
+			Consistency:       si1,
+			SerialConsistency: si2,
+			Timestamp:         li1,
+		}
+		var buf frame.Buffer
+		in.WriteTo(&buf)
+		if buf.Error() != nil {
+			t.Error(buf.Error())
+		}
+	})
+}

--- a/frame/request/execute_test.go
+++ b/frame/request/execute_test.go
@@ -33,3 +33,27 @@ func TestExecuteWriteTo(t *testing.T) {
 		})
 	}
 }
+
+// We want to make sure that parsing does not crush driver even for random data.
+func FuzzExecute(f *testing.F) {
+	f.Fuzz(func(t *testing.T, b1 byte, si1, si2 uint16, i1, i2 int32, li1 int64, s1, s2 string, bs1, bs2, bs3 []byte) { // nolint:thelper // This is not a helper function.
+		in := Execute{
+			ID:          bs1,
+			Consistency: si1,
+			Options: frame.QueryOptions{
+				Flags:             b1,
+				Values:            []frame.Value{{N: i1, Bytes: bs2}},
+				Names:             frame.StringList{s1, s2},
+				PageSize:          i2,
+				PagingState:       bs3,
+				SerialConsistency: si2,
+				Timestamp:         li1,
+			},
+		}
+		var buf frame.Buffer
+		in.WriteTo(&buf)
+		if buf.Error() != nil {
+			t.Error(buf.Error())
+		}
+	})
+}

--- a/frame/request/prepare_test.go
+++ b/frame/request/prepare_test.go
@@ -37,3 +37,15 @@ func TestPrepare(t *testing.T) {
 		})
 	}
 }
+
+// We want to make sure that parsing does not crush driver even for random data.
+func FuzzPrepare(f *testing.F) {
+	f.Fuzz(func(t *testing.T, s string) { // nolint:thelper // This is not a helper function.
+		in := Prepare{Query: s}
+		var buf frame.Buffer
+		in.WriteTo(&buf)
+		if buf.Error() != nil {
+			t.Error(buf.Error())
+		}
+	})
+}

--- a/frame/request/query_test.go
+++ b/frame/request/query_test.go
@@ -141,3 +141,27 @@ func TestQuery(t *testing.T) {
 		})
 	}
 }
+
+// We want to make sure that parsing does not crush driver even for random data.
+func FuzzQuery(f *testing.F) {
+	f.Fuzz(func(t *testing.T, b1 byte, si1, si2 uint16, i1, i2 int32, li1 int64, s1, s2, s3 string, bs1, bs2 []byte) { // nolint:thelper // This is not a helper function.
+		in := Query{
+			Query:       s1,
+			Consistency: si1,
+			Options: frame.QueryOptions{
+				Flags:             b1,
+				Values:            []frame.Value{{N: i1, Bytes: bs1}},
+				Names:             frame.StringList{s2, s3},
+				PageSize:          i2,
+				PagingState:       bs2,
+				SerialConsistency: si2,
+				Timestamp:         li1,
+			},
+		}
+		var buf frame.Buffer
+		in.WriteTo(&buf)
+		if buf.Error() != nil {
+			t.Error(buf.Error())
+		}
+	})
+}

--- a/frame/request/register_test.go
+++ b/frame/request/register_test.go
@@ -40,3 +40,15 @@ func TestRegister(t *testing.T) {
 		})
 	}
 }
+
+// We want to make sure that parsing does not crush driver even for random data.
+func FuzzRegister(f *testing.F) {
+	f.Fuzz(func(t *testing.T, s1, s2, s3 string) { // nolint:thelper // This is not a helper function.
+		in := Register{EventTypes: []frame.EventType{s1, s2, s3}}
+		var buf frame.Buffer
+		in.WriteTo(&buf)
+		if buf.Error() != nil {
+			t.Error(buf.Error())
+		}
+	})
+}

--- a/frame/request/startup_test.go
+++ b/frame/request/startup_test.go
@@ -45,3 +45,15 @@ func TestWriteStartup(t *testing.T) {
 		})
 	}
 }
+
+// We want to make sure that parsing does not crush driver even for random data.
+func FuzzStartup(f *testing.F) {
+	f.Fuzz(func(t *testing.T, s1, s2, s3, s4, s5, s6 string) { // nolint:thelper // This is not a helper function.
+		in := Startup{Options: frame.StartupOptions{s1: s2, s3: s4, s5: s6}}
+		var buf frame.Buffer
+		in.WriteTo(&buf)
+		if buf.Error() != nil {
+			t.Error(buf.Error())
+		}
+	})
+}

--- a/frame/response/authchallenge_test.go
+++ b/frame/response/authchallenge_test.go
@@ -53,3 +53,20 @@ func TestAuthChallenge(t *testing.T) {
 		})
 	}
 }
+
+var dummyAC *AuthChallenge
+
+// We want to make sure that parsing does not crush driver even for random data.
+// We assign result to global variable to avoid compiler optimization.
+func FuzzAuthChallenge(f *testing.F) {
+	testCases := [][]byte{make([]byte, 1000000)}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
+		var buf frame.Buffer
+		buf.Write(data)
+		out := ParseAuthChallenge(&buf)
+		dummyAC = out
+	})
+}

--- a/frame/response/authenticate_test.go
+++ b/frame/response/authenticate_test.go
@@ -37,3 +37,20 @@ func TestAuthenticateEncodeDecode(t *testing.T) {
 		})
 	}
 }
+
+var dummyA *Authenticate
+
+// We want to make sure that parsing does not crush driver even for random data.
+// We assign result to global variable to avoid compiler optimization.
+func FuzzAuthenticate(f *testing.F) {
+	testCases := [][]byte{make([]byte, 1000000)}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
+		var buf frame.Buffer
+		buf.Write(data)
+		out := ParseAuthenticate(&buf)
+		dummyA = out
+	})
+}

--- a/frame/response/authsuccess_test.go
+++ b/frame/response/authsuccess_test.go
@@ -34,3 +34,20 @@ func TestAuthSuccessEncodeDecode(t *testing.T) {
 		})
 	}
 }
+
+var dummyAS *AuthSuccess
+
+// We want to make sure that parsing does not crush driver even for random data.
+// We assign result to global variable to avoid compiler optimization.
+func FuzzAuthSuccess(f *testing.F) {
+	testCases := [][]byte{make([]byte, 1000000)}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
+		var buf frame.Buffer
+		buf.Write(data)
+		out := ParseAuthSuccess(&buf)
+		dummyAS = out
+	})
+}

--- a/frame/response/error_test.go
+++ b/frame/response/error_test.go
@@ -316,3 +316,120 @@ func TestUnpreparedError(t *testing.T) {
 		})
 	}
 }
+
+var (
+	dummyUAE *UnavailableError
+	dummyWTE *WriteTimeoutError
+	dummyRTE *ReadTimeoutError
+	dummyRFE *ReadFailureError
+	dummyFFE *FuncFailureError
+	dummyWFE *WriteFailureError
+	dummyAEE *AlreadyExistsError
+	dummyUPE *UnpreparedError
+)
+
+// We want to make sure that parsing does not crush driver even for random data.
+// We assign result to global variable to avoid compiler optimization.
+func FuzzUnavailableError(f *testing.F) {
+	testCases := [][]byte{make([]byte, 1000000)}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
+		var buf frame.Buffer
+		buf.Write(data)
+		out := ParseUnavailableError(&buf)
+		dummyUAE = out
+	})
+}
+
+func FuzzWriteTimeoutErrorError(f *testing.F) {
+	testCases := [][]byte{make([]byte, 1000000)}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
+		var buf frame.Buffer
+		buf.Write(data)
+		out := ParseWriteTimeoutError(&buf)
+		dummyWTE = out
+	})
+}
+
+func FuzzReadTimeoutError(f *testing.F) {
+	testCases := [][]byte{make([]byte, 1000000)}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
+		var buf frame.Buffer
+		buf.Write(data)
+		out := ParseReadTimeoutError(&buf)
+		dummyRTE = out
+	})
+}
+
+func FuzzReadFailureErrorError(f *testing.F) {
+	testCases := [][]byte{make([]byte, 1000000)}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
+		var buf frame.Buffer
+		buf.Write(data)
+		out := ParseReadFailureError(&buf)
+		dummyRFE = out
+	})
+}
+
+func FuzzFuncFailureError(f *testing.F) {
+	testCases := [][]byte{make([]byte, 1000000)}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
+		var buf frame.Buffer
+		buf.Write(data)
+		out := ParseFuncFailureError(&buf)
+		dummyFFE = out
+	})
+}
+
+func FuzzWriteFailureError(f *testing.F) {
+	testCases := [][]byte{make([]byte, 1000000)}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
+		var buf frame.Buffer
+		buf.Write(data)
+		out := ParseWriteFailureError(&buf)
+		dummyWFE = out
+	})
+}
+
+func FuzzParseAlreadyExistsError(f *testing.F) {
+	testCases := [][]byte{make([]byte, 1000000)}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
+		var buf frame.Buffer
+		buf.Write(data)
+		out := ParseAlreadyExistsError(&buf)
+		dummyAEE = out
+	})
+}
+
+func FuzzUnpreparedError(f *testing.F) {
+	testCases := [][]byte{make([]byte, 1000000)}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
+		var buf frame.Buffer
+		buf.Write(data)
+		out := ParseUnpreparedError(&buf)
+		dummyUPE = out
+	})
+}

--- a/frame/response/event_test.go
+++ b/frame/response/event_test.go
@@ -194,3 +194,50 @@ func TestSchemaChangeEvent(t *testing.T) {
 		})
 	}
 }
+
+var (
+	dummyStaC *StatusChange
+	dummyTopC *TopologyChange
+	dummySchC *SchemaChange
+)
+
+// We want to make sure that parsing does not crush driver even for random data.
+// We assign result to global variable to avoid compiler optimization.
+func FuzzStatusChange(f *testing.F) {
+	testCases := [][]byte{make([]byte, 1000000)}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
+		var buf frame.Buffer
+		buf.Write(data)
+		out := ParseStatusChange(&buf)
+		dummyStaC = out
+	})
+}
+
+func FuzzTopologyChange(f *testing.F) {
+	testCases := [][]byte{make([]byte, 1000000)}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
+		var buf frame.Buffer
+		buf.Write(data)
+		out := ParseTopologyChange(&buf)
+		dummyTopC = out
+	})
+}
+
+func FuzzSchemaChange(f *testing.F) {
+	testCases := [][]byte{make([]byte, 1000000)}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
+		var buf frame.Buffer
+		buf.Write(data)
+		out := ParseSchemaChange(&buf)
+		dummySchC = out
+	})
+}

--- a/frame/response/result_test.go
+++ b/frame/response/result_test.go
@@ -1,11 +1,11 @@
 package response
 
 import (
-	"github.com/google/go-cmp/cmp"
+	"testing"
 
 	"github.com/mmatczuk/scylla-go-driver/frame"
 
-	"testing"
+	"github.com/google/go-cmp/cmp"
 )
 
 var (
@@ -477,4 +477,65 @@ func TestSchemaChangeResult(t *testing.T) {
 			}
 		})
 	}
+}
+
+var (
+	dummyRR *RowsResult
+	dummySK *SetKeyspaceResult
+	dummyP  *PreparedResult
+	dummySC *SchemaChangeResult
+)
+
+// We want to make sure that parsing does not crush driver even for random data.
+// We assign result to global variable to avoid compiler optimization.
+func FuzzRowsResult(f *testing.F) {
+	testCases := [][]byte{make([]byte, 1000000)}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
+		var buf frame.Buffer
+		buf.Write(data)
+		out := ParseRowsResult(&buf)
+		dummyRR = out
+	})
+}
+
+func FuzzSetKeyspaceResult(f *testing.F) {
+	testCases := [][]byte{make([]byte, 1000000)}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
+		var buf frame.Buffer
+		buf.Write(data)
+		out := ParseSetKeyspaceResult(&buf)
+		dummySK = out
+	})
+}
+
+func FuzzPreparedResult(f *testing.F) {
+	testCases := [][]byte{make([]byte, 1000000)}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
+		var buf frame.Buffer
+		buf.Write(data)
+		out := ParsePreparedResult(&buf)
+		dummyP = out
+	})
+}
+
+func FuzzSchemaChangeResultResult(f *testing.F) {
+	testCases := [][]byte{make([]byte, 1000000)}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
+		var buf frame.Buffer
+		buf.Write(data)
+		out := ParseSchemaChangeResult(&buf)
+		dummySC = out
+	})
 }

--- a/frame/response/supported_test.go
+++ b/frame/response/supported_test.go
@@ -95,3 +95,20 @@ func TestParseScyllaSupported(t *testing.T) {
 		})
 	}
 }
+
+var dummyS *Supported
+
+// We want to make sure that parsing does not crush driver even for random data.
+// We assign result to global variable to avoid compiler optimization.
+func FuzzSupported(f *testing.F) {
+	testCases := [][]byte{make([]byte, 1000000)}
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) { // nolint:thelper // This is not a helper function.
+		var buf frame.Buffer
+		buf.Write(data)
+		out := ParseSupported(&buf)
+		dummyS = out
+	})
+}


### PR DESCRIPTION
Changes:
```
- added fuzzing for buffer tests
- added fuzzing for cql value tests
  - both of those are based on the fact that deserialize(serialize(x)) == x
    and they test behaviour for correct input
- added fuzzing for requests and responses
  - the last checks if writing and reading frames doesn't cause program to crash
    for random data (mostly incorrect input)
- discovered and fixed vulnerability in buffers 'readCopy' method, where
  even for corrupted or enormously large int, driver would still try to allocate
  slice of given length causing program to crash
```
Fixes #191 