### PR TITLE
transport: pool: connection reopening improvement

### DIFF
--- a/transport/pool.go
+++ b/transport/pool.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/mmatczuk/scylla-go-driver/frame"
 	. "github.com/mmatczuk/scylla-go-driver/frame/response"
 
 	"go.uber.org/atomic"
@@ -121,10 +122,11 @@ func (p *ConnPool) closeAll() {
 }
 
 type PoolRefiller struct {
-	addr   string
-	pool   ConnPool
-	cfg    ConnConfig
-	active int
+	addr     string
+	pool     ConnPool
+	cfg      ConnConfig
+	active   int
+	authFail []bool
 }
 
 func (r *PoolRefiller) init(host string) error {
@@ -167,6 +169,7 @@ func (r *PoolRefiller) init(host string) error {
 	conn.setOnClose(r.onConnClose)
 	r.pool.storeConn(conn)
 	r.active = 1
+	r.authFail = make([]bool, int(ss.NrShards))
 	if r.pool.connObs != nil {
 		r.pool.connObs.OnConnect(ConnectEvent{ConnEvent: conn.Event(), span: span})
 	}
@@ -216,7 +219,7 @@ func (r *PoolRefiller) fill() {
 	}
 
 	for i := 0; i < r.pool.nrShards; i++ {
-		if r.pool.loadConn(i) != nil {
+		if r.authFail[i] || r.pool.loadConn(i) != nil {
 			continue
 		}
 
@@ -225,6 +228,10 @@ func (r *PoolRefiller) fill() {
 		conn, err := OpenShardConn(r.addr, si, r.cfg)
 		span.stop()
 		if err != nil {
+			e, ok := err.(CodedError)
+			if ok && e.ErrorCode() == frame.ErrCodeCredentials {
+				r.authFail[i] = true
+			}
 			if r.pool.connObs != nil {
 				r.pool.connObs.OnConnect(ConnectEvent{ConnEvent: ConnEvent{Addr: r.addr, Shard: si.Shard}, span: span, Err: err})
 			}


### PR DESCRIPTION
Refiller now doesn't try to open a connection to those shards which returned an Authentication error (https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L1056-L1059) when it tried to connect to them.

Fixes #214 