### PR TITLE
Pp/drop keyspace fix

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 COMPOSE_PROJECT_NAME="scylla_go_driver"
 
 SCYLLA_IMAGE=scylladb/scylla
-SCYLLA_VERSION=4.6.1
+SCYLLA_VERSION=5.0.0
 SCYLLA_ARGS="--smp 4 --memory 4G --authenticator PasswordAuthenticator"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.45
+          version: v1.46.2
 
       - name: Run tests
         run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,7 @@ linters:
     - errorlint
     - exhaustive
     - exhaustivestruct
+    - exhaustruct
     - forbidigo
     - forcetypeassert
     - funlen
@@ -50,6 +51,7 @@ linters:
     - ireturn
     - maligned
     - nlreturn
+    - nonamedreturns
     - nolintlint
     - prealloc
     - promlinter

--- a/session_integration_bench_test.go
+++ b/session_integration_bench_test.go
@@ -10,9 +10,9 @@ func BenchmarkSessionQueryIntegration(b *testing.B) {
 	session := newTestSession(b)
 
 	initStmts := []string{
-		"DROP KEYSPACE IF EXISTS mykeyspace",
 		"CREATE KEYSPACE IF NOT EXISTS mykeyspace WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}",
 		"CREATE TABLE IF NOT EXISTS mykeyspace.triples (pk bigint PRIMARY KEY, v1 bigint, v2 bigint)",
+		"TRUNCATE TABLE mykeyspace.triples",
 	}
 
 	for _, stmt := range initStmts {
@@ -70,9 +70,9 @@ func BenchmarkSessionAsyncQueryIntegration(b *testing.B) {
 	session := newTestSession(b)
 
 	initStmts := []string{
-		"DROP KEYSPACE IF EXISTS mykeyspace",
 		"CREATE KEYSPACE IF NOT EXISTS mykeyspace WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}",
 		"CREATE TABLE IF NOT EXISTS mykeyspace.triples (pk bigint PRIMARY KEY, v1 bigint, v2 bigint)",
+		"TRUNCATE TABLE mykeyspace.triples",
 	}
 
 	for _, stmt := range initStmts {

--- a/session_integration_test.go
+++ b/session_integration_test.go
@@ -96,9 +96,9 @@ func TestSessionPrepareIntegration(t *testing.T) { // nolint:paralleltest // Int
 	defer session.Close()
 
 	initStmts := []string{
-		"DROP KEYSPACE IF EXISTS mykeyspace",
 		"CREATE KEYSPACE IF NOT EXISTS mykeyspace WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}",
 		"CREATE TABLE IF NOT EXISTS mykeyspace.triples (pk bigint PRIMARY KEY, v1 bigint, v2 bigint)",
+		"TRUNCATE mykeyspace.triples",
 	}
 
 	for _, stmt := range initStmts {
@@ -155,9 +155,9 @@ func TestSessionIterIntegration(t *testing.T) { // nolint:paralleltest // Integr
 	defer session.Close()
 
 	initStmts := []string{
-		"DROP KEYSPACE IF EXISTS mykeyspace",
 		"CREATE KEYSPACE IF NOT EXISTS mykeyspace WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}",
 		"CREATE TABLE IF NOT EXISTS mykeyspace.triples (pk bigint PRIMARY KEY, v1 bigint, v2 bigint)",
+		"TRUNCATE TABLE mykeyspace.triples",
 	}
 
 	for _, stmt := range initStmts {

--- a/transport/conn_integration_test.go
+++ b/transport/conn_integration_test.go
@@ -47,6 +47,7 @@ func newConnTestHelper(t testing.TB) *connTestHelper {
 func (h *connTestHelper) applyFixture() {
 	h.exec("CREATE KEYSPACE IF NOT EXISTS mykeyspace WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}")
 	h.exec("CREATE TABLE IF NOT EXISTS mykeyspace.users (user_id int, fname text, lname text, PRIMARY KEY((user_id)))")
+	h.exec("TRUNCATE TABLE mykeyspace.users")
 	h.exec("INSERT INTO mykeyspace.users(user_id, fname, lname) VALUES (1, 'rick', 'sanchez')")
 	h.exec("INSERT INTO mykeyspace.users(user_id, fname, lname) VALUES (4, 'rust', 'cohle')")
 	if err := h.conn.UseKeyspace("mykeyspace"); err != nil {
@@ -57,6 +58,7 @@ func (h *connTestHelper) applyFixture() {
 func (h *connTestHelper) setupMassiveUsersTable() {
 	h.exec("CREATE KEYSPACE IF NOT EXISTS mykeyspace WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}")
 	h.exec("CREATE TABLE IF NOT EXISTS mykeyspace.massive_users (user_id int, fname text, lname text, PRIMARY KEY((user_id)))")
+	h.exec("TRUNCATE TABLE mykeyspace.massive_users")
 }
 
 func (h *connTestHelper) exec(cql string) {
@@ -83,7 +85,6 @@ func TestConnMassiveQueryIntegration(t *testing.T) {
 	h := newConnTestHelper(t)
 	h.setupMassiveUsersTable()
 	defer h.close()
-	defer h.exec("DROP KEYSPACE mykeyspace")
 
 	const n = maxStreamID
 
@@ -149,7 +150,6 @@ func TestCloseHangingIntegration(t *testing.T) {
 			}
 			// Shut the connection down in the middle of querying
 			if id == n/2 {
-				h.exec("DROP KEYSPACE mykeyspace")
 				h.conn.Close()
 			}
 		}(i)


### PR DESCRIPTION
Replaced dropping keyspaces and tables with table truncating in tests to avoid missing keyspace errors.